### PR TITLE
feat(#104): Design system and component library 

### DIFF
--- a/app/frontend/.storybook/main.ts
+++ b/app/frontend/.storybook/main.ts
@@ -1,0 +1,18 @@
+import type { StorybookConfig } from '@storybook/nextjs';
+
+const config: StorybookConfig = {
+  stories: [
+    '../components/ui/**/*.stories.@(js|jsx|mjs|ts|tsx)',
+  ],
+  addons: [
+    '@storybook/addon-essentials',
+    '@storybook/addon-a11y',
+  ],
+  framework: {
+    name: '@storybook/nextjs',
+    options: {},
+  },
+  staticDirs: ['../public'],
+};
+
+export default config;

--- a/app/frontend/.storybook/preview.ts
+++ b/app/frontend/.storybook/preview.ts
@@ -1,0 +1,25 @@
+import type { Preview } from '@storybook/react';
+import '../app/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+    layout: 'centered',
+    a11y: {
+      config: {
+        rules: [
+          { id: 'color-contrast', enabled: true },
+          { id: 'label', enabled: true },
+          { id: 'button-name', enabled: true },
+        ],
+      },
+    },
+  },
+};
+
+export default preview;

--- a/app/frontend/app/globals.css
+++ b/app/frontend/app/globals.css
@@ -1,26 +1,181 @@
 @import "tailwindcss";
 
+/* ==========================================================================
+   Gatherraa Design Tokens (token-based theming)
+   ========================================================================== */
+
 :root {
+  /* Surfaces & background */
   --background: #ffffff;
   --foreground: #171717;
-}
+  --surface: #ffffff;
+  --surface-elevated: #f9fafb;
+  --surface-overlay: #ffffff;
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /* Semantic colors */
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-primary-active: #1e40af;
+  --color-primary-muted: #dbeafe;
+  --color-primary-muted-foreground: #1e40af;
+
+  --color-success: #16a34a;
+  --color-success-muted: #dcfce7;
+  --color-success-muted-foreground: #166534;
+
+  --color-warning: #d97706;
+  --color-warning-muted: #fef3c7;
+  --color-warning-muted-foreground: #92400e;
+
+  --color-error: #dc2626;
+  --color-error-muted: #fee2e2;
+  --color-error-muted-foreground: #991b1b;
+
+  --color-info: #2563eb;
+  --color-info-muted: #dbeafe;
+  --color-info-muted-foreground: #1e40af;
+
+  /* Neutral palette */
+  --gray-50: #f9fafb;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
+  --gray-700: #374151;
+  --gray-800: #1f2937;
+  --gray-900: #111827;
+  --gray-950: #030712;
+
+  /* Text */
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-muted: #6b7280;
+  --text-inverse: #ffffff;
+
+  /* Borders */
+  --border-default: #e5e7eb;
+  --border-muted: #f3f4f6;
+  --radius-sm: 0.375rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  /* Spacing (scale) */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+
+  /* Typography */
+  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, monospace;
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+  --font-medium: 500;
+  --font-semibold: 600;
+  --font-bold: 700;
+
+  /* Focus (accessibility) */
+  --focus-ring: 2px solid var(--color-primary);
+  --focus-ring-offset: 2px;
+  --focus-outline: 2px solid var(--color-primary);
+  --focus-outline-offset: 2px;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --surface: #1f2937;
+    --surface-elevated: #374151;
+    --surface-overlay: #111827;
+
+    --color-primary: #3b82f6;
+    --color-primary-hover: #2563eb;
+    --color-primary-active: #1d4ed8;
+    --color-primary-muted: rgba(59, 130, 246, 0.2);
+    --color-primary-muted-foreground: #93c5fd;
+
+    --color-success: #22c55e;
+    --color-success-muted: rgba(34, 197, 94, 0.2);
+    --color-success-muted-foreground: #86efac;
+
+    --color-warning: #f59e0b;
+    --color-warning-muted: rgba(245, 158, 11, 0.2);
+    --color-warning-muted-foreground: #fcd34d;
+
+    --color-error: #ef4444;
+    --color-error-muted: rgba(239, 68, 68, 0.2);
+    --color-error-muted-foreground: #fca5a5;
+
+    --color-info: #3b82f6;
+    --color-info-muted: rgba(59, 130, 246, 0.2);
+    --color-info-muted-foreground: #93c5fd;
+
+    --text-primary: #f9fafb;
+    --text-secondary: #d1d5db;
+    --text-muted: #9ca3af;
+    --text-inverse: #111827;
+
+    --border-default: #374151;
+    --border-muted: #1f2937;
   }
+}
+
+/* Tailwind @theme: map tokens to utilities */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-primary: var(--color-primary);
+  --color-primary-hover: var(--color-primary-hover);
+  --color-primary-muted: var(--color-primary-muted);
+  --color-success: var(--color-success);
+  --color-success-muted: var(--color-success-muted);
+  --color-warning: var(--color-warning);
+  --color-warning-muted: var(--color-warning-muted);
+  --color-error: var(--color-error);
+  --color-error-muted: var(--color-error-muted);
+  --color-info: var(--color-info);
+  --color-info-muted: var(--color-info-muted);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --radius-sm: var(--radius-sm);
+  --radius-md: var(--radius-md);
+  --radius-lg: var(--radius-lg);
+  --radius-xl: var(--radius-xl);
+  --radius-full: var(--radius-full);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
+}
+
+/* Accessible focus visible (keyboard only) */
+:focus {
+  outline: none;
+}
+:focus-visible {
+  outline: var(--focus-outline);
+  outline-offset: var(--focus-outline-offset);
 }

--- a/app/frontend/components/dao/StatusBadge.tsx
+++ b/app/frontend/components/dao/StatusBadge.tsx
@@ -1,28 +1,20 @@
 import React from 'react';
+import { Badge, type BadgeVariant } from '@/components/ui';
 
 interface StatusBadgeProps {
   status: 'Active' | 'Passed' | 'Failed';
 }
 
-const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => {
-  const getStatusStyles = () => {
-    switch (status) {
-      case 'Active':
-        return 'bg-blue-100 dark:bg-blue-900/20 text-blue-800 dark:text-blue-200';
-      case 'Passed':
-        return 'bg-green-100 dark:bg-green-900/20 text-green-800 dark:text-green-200';
-      case 'Failed':
-        return 'bg-red-100 dark:bg-red-900/20 text-red-800 dark:text-red-200';
-      default:
-        return 'bg-gray-100 dark:bg-gray-900/20 text-gray-800 dark:text-gray-200';
-    }
-  };
-
-  return (
-    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusStyles()}`}>
-      {status}
-    </span>
-  );
+const statusVariant: Record<StatusBadgeProps['status'], BadgeVariant> = {
+  Active: 'info',
+  Passed: 'success',
+  Failed: 'error',
 };
+
+const StatusBadge: React.FC<StatusBadgeProps> = ({ status }) => (
+  <Badge variant={statusVariant[status]} aria-label={`Proposal status: ${status}`}>
+    {status}
+  </Badge>
+);
 
 export default StatusBadge;

--- a/app/frontend/components/ui/README.md
+++ b/app/frontend/components/ui/README.md
@@ -1,0 +1,39 @@
+# Gatherraa Design System
+
+Shared component library with **atomic design** structure and **token-based theming**.
+
+## Structure
+
+- **Atoms** – Basic building blocks: `Button`, `Badge`, `Input`, `Text`
+- **Molecules** – Composed components: `Card`, `FormField`, `StarRating`
+- **Organisms** – Page-specific compositions live in `components/dao`, `components/wallet`, etc., and use atoms/molecules
+
+## Theming (Design Tokens)
+
+Tokens are defined in `app/globals.css` under `:root` and `@media (prefers-color-scheme: dark)`:
+
+- **Surfaces**: `--background`, `--foreground`, `--surface`, `--surface-elevated`
+- **Semantic colors**: `--color-primary`, `--color-success`, `--color-warning`, `--color-error`, `--color-info` (and `-muted` variants)
+- **Typography**: `--font-sans`, `--font-mono`, `--text-primary`, `--text-secondary`, `--text-muted`
+- **Spacing & radius**: `--radius-sm` through `--radius-full`, `--space-1` through `--space-12`
+- **Focus**: `--focus-outline`, `--focus-outline-offset` for accessibility
+
+Components use these via `var(--token-name)` in class names (e.g. `bg-[var(--color-primary)]`).
+
+## Usage
+
+```tsx
+import { Button, Badge, Card, FormField, StarRating } from '@/components/ui';
+```
+
+## Storybook
+
+- **Run**: `npm run storybook` (port 6006)
+- **Build**: `npm run build-storybook`
+- Stories live next to components (`*.stories.tsx`). The **Accessibility** addon (a11y) is enabled for compliance checks.
+
+## Accessibility
+
+- Focus visible styles use design tokens; `:focus-visible` is applied in `globals.css`.
+- Components use semantic HTML and ARIA where needed (`role="status"` on Badge, `aria-label` support, `aria-invalid` on inputs, etc.).
+- Run a11y checks in Storybook via the "Accessibility" tab.

--- a/app/frontend/components/ui/atoms/Badge/Badge.stories.tsx
+++ b/app/frontend/components/ui/atoms/Badge/Badge.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Badge } from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Design System/Atoms/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['default', 'success', 'warning', 'error', 'info'] },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = { args: { children: 'Draft', variant: 'default' } };
+export const Success: Story = { args: { children: 'Passed', variant: 'success' } };
+export const Info: Story = { args: { children: 'Active', variant: 'info' } };

--- a/app/frontend/components/ui/atoms/Badge/Badge.tsx
+++ b/app/frontend/components/ui/atoms/Badge/Badge.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'error' | 'info';
+
+export interface BadgeProps {
+  variant?: BadgeVariant;
+  children: React.ReactNode;
+  className?: string;
+  /** Accessible label when content is not descriptive (e.g. status only) */
+  'aria-label'?: string;
+}
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default:
+    'bg-[var(--gray-100)] dark:bg-[var(--gray-800)] text-[var(--text-secondary)]',
+  success:
+    'bg-[var(--color-success-muted)] text-[var(--color-success-muted-foreground)] dark:bg-[var(--color-success-muted)] dark:text-[var(--color-success-muted-foreground)]',
+  warning:
+    'bg-[var(--color-warning-muted)] text-[var(--color-warning-muted-foreground)] dark:bg-[var(--color-warning-muted)] dark:text-[var(--color-warning-muted-foreground)]',
+  error:
+    'bg-[var(--color-error-muted)] text-[var(--color-error-muted-foreground)] dark:bg-[var(--color-error-muted)] dark:text-[var(--color-error-muted-foreground)]',
+  info:
+    'bg-[var(--color-info-muted)] text-[var(--color-info-muted-foreground)] dark:bg-[var(--color-info-muted)] dark:text-[var(--color-info-muted-foreground)]',
+};
+
+export function Badge({
+  variant = 'default',
+  children,
+  className = '',
+  'aria-label': ariaLabel,
+}: BadgeProps) {
+  const base =
+    'inline-flex items-center px-2 py-1 text-xs font-semibold rounded-full';
+  const variantClass = variantClasses[variant];
+
+  return (
+    <span
+      className={`${base} ${variantClass} ${className}`}
+      role="status"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </span>
+  );
+}

--- a/app/frontend/components/ui/atoms/Badge/index.ts
+++ b/app/frontend/components/ui/atoms/Badge/index.ts
@@ -1,0 +1,2 @@
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeVariant } from './Badge';

--- a/app/frontend/components/ui/atoms/Button/Button.stories.tsx
+++ b/app/frontend/components/ui/atoms/Button/Button.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from './Button';
+
+const meta: Meta<typeof Button> = {
+  title: 'Design System/Atoms/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: { control: 'select', options: ['primary', 'secondary', 'ghost', 'danger', 'outline'] },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    disabled: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Primary: Story = { args: { children: 'Connect Wallet', variant: 'primary' } };
+export const Secondary: Story = { args: { children: 'Cancel', variant: 'secondary' } };
+export const FullWidth: Story = { args: { children: 'Full width', fullWidth: true } };

--- a/app/frontend/components/ui/atoms/Button/Button.tsx
+++ b/app/frontend/components/ui/atoms/Button/Button.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'outline';
+type ButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  fullWidth?: boolean;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-[var(--color-primary)] text-white hover:bg-[var(--color-primary-hover)] active:bg-[var(--color-primary-active)] shadow-sm',
+  secondary:
+    'bg-[var(--surface-elevated)] text-[var(--text-primary)] border border-[var(--border-default)] hover:bg-[var(--gray-100)] dark:hover:bg-[var(--gray-700)]',
+  ghost:
+    'bg-transparent text-[var(--text-secondary)] hover:bg-[var(--gray-100)] dark:hover:bg-[var(--gray-800)]',
+  danger:
+    'bg-[var(--color-error)] text-white hover:bg-red-600 dark:hover:bg-red-700',
+  outline:
+    'border-2 border-[var(--color-primary)] text-[var(--color-primary)] bg-transparent hover:bg-[var(--color-primary-muted)]',
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-sm gap-1.5',
+  md: 'px-4 py-2 text-sm gap-2',
+  lg: 'px-6 py-3 text-base gap-3',
+};
+
+const iconSizeClasses: Record<ButtonSize, string> = {
+  sm: 'w-4 h-4',
+  md: 'w-4 h-4',
+  lg: 'w-5 h-5',
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      variant = 'primary',
+      size = 'md',
+      fullWidth,
+      leftIcon,
+      rightIcon,
+      children,
+      className = '',
+      disabled,
+      ...props
+    },
+    ref
+  ) => {
+    const base =
+      'inline-flex items-center justify-center font-semibold rounded-xl transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+    const variantClass = variantClasses[variant];
+    const sizeClass = sizeClasses[size];
+    const iconSize = iconSizeClasses[size];
+    const widthClass = fullWidth ? 'w-full' : '';
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        disabled={disabled}
+        className={`${base} ${variantClass} ${sizeClass} ${widthClass} ${className}`}
+        {...props}
+      >
+        {leftIcon && (
+          <span className={iconSize} aria-hidden>
+            {leftIcon}
+          </span>
+        )}
+        {children}
+        {rightIcon && (
+          <span className={iconSize} aria-hidden>
+            {rightIcon}
+          </span>
+        )}
+      </button>
+    );
+  }
+);
+
+Button.displayName = 'Button';

--- a/app/frontend/components/ui/atoms/Button/index.ts
+++ b/app/frontend/components/ui/atoms/Button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export type { ButtonProps } from './Button';

--- a/app/frontend/components/ui/atoms/Input/Input.stories.tsx
+++ b/app/frontend/components/ui/atoms/Input/Input.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Design System/Atoms/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    error: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    placeholder: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: 'Enter value...',
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    placeholder: 'Search...',
+    defaultValue: 'Gatherraa',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    placeholder: 'Invalid input',
+    error: true,
+    defaultValue: 'invalid',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: 'Disabled',
+    disabled: true,
+  },
+};
+
+export const FullWidth: Story = {
+  args: {
+    placeholder: 'Full width input',
+    fullWidth: true,
+  },
+};

--- a/app/frontend/components/ui/atoms/Input/Input.tsx
+++ b/app/frontend/components/ui/atoms/Input/Input.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import React, { forwardRef } from 'react';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean;
+  fullWidth?: boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ error, fullWidth, className = '', ...props }, ref) => {
+    const base =
+      'px-4 py-2 text-[var(--text-primary)] bg-[var(--surface)] border rounded-lg transition-colors placeholder:text-[var(--text-muted)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:border-transparent disabled:opacity-50 disabled:cursor-not-allowed';
+    const borderClass = error
+      ? 'border-[var(--color-error)]'
+      : 'border-[var(--border-default)] dark:border-[var(--gray-600)] hover:border-[var(--gray-400)] focus:border-[var(--color-primary)]';
+    const widthClass = fullWidth ? 'w-full' : '';
+
+    return (
+      <input
+        ref={ref}
+        className={`${base} ${borderClass} ${widthClass} ${className}`}
+        aria-invalid={error ? 'true' : undefined}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export { Input };

--- a/app/frontend/components/ui/atoms/Input/index.ts
+++ b/app/frontend/components/ui/atoms/Input/index.ts
@@ -1,0 +1,2 @@
+export { Input } from './Input';
+export type { InputProps } from './Input';

--- a/app/frontend/components/ui/atoms/Text/Text.stories.tsx
+++ b/app/frontend/components/ui/atoms/Text/Text.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Text } from './Text';
+
+const meta: Meta<typeof Text> = {
+  title: 'Design System/Atoms/Text',
+  component: Text,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['body', 'caption', 'label', 'heading-sm', 'heading-md', 'heading-lg'],
+    },
+    color: {
+      control: 'select',
+      options: ['primary', 'secondary', 'muted', 'inverse'],
+    },
+    as: {
+      control: 'select',
+      options: ['p', 'span', 'div', 'label', 'h1', 'h2', 'h3'],
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Text>;
+
+export const Body: Story = {
+  args: {
+    variant: 'body',
+    children: 'Body text for paragraphs and general content.',
+  },
+};
+
+export const Caption: Story = {
+  args: {
+    variant: 'caption',
+    children: 'Caption or secondary information.',
+  },
+};
+
+export const Label: Story = {
+  args: {
+    variant: 'label',
+    children: 'Form label',
+  },
+};
+
+export const HeadingSmall: Story = {
+  args: {
+    variant: 'heading-sm',
+    as: 'h3',
+    children: 'Heading small',
+  },
+};
+
+export const HeadingMedium: Story = {
+  args: {
+    variant: 'heading-md',
+    as: 'h2',
+    children: 'Heading medium',
+  },
+};
+
+export const HeadingLarge: Story = {
+  args: {
+    variant: 'heading-lg',
+    as: 'h1',
+    children: 'Heading large',
+  },
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Text color="primary">Primary text</Text>
+      <Text color="secondary">Secondary text</Text>
+      <Text color="muted">Muted text</Text>
+    </div>
+  ),
+};

--- a/app/frontend/components/ui/atoms/Text/Text.tsx
+++ b/app/frontend/components/ui/atoms/Text/Text.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import React from 'react';
+
+type TextVariant = 'body' | 'caption' | 'label' | 'heading-sm' | 'heading-md' | 'heading-lg';
+type TextColor = 'primary' | 'secondary' | 'muted' | 'inverse';
+
+export interface TextProps {
+  variant?: TextVariant;
+  color?: TextColor;
+  as?: 'p' | 'span' | 'div' | 'label' | 'h1' | 'h2' | 'h3';
+  children: React.ReactNode;
+  className?: string;
+  id?: string;
+  htmlFor?: string;
+}
+
+const variantClasses: Record<TextVariant, string> = {
+  body: 'text-base',
+  caption: 'text-sm',
+  label: 'text-sm font-medium',
+  'heading-sm': 'text-lg font-semibold',
+  'heading-md': 'text-xl font-semibold',
+  'heading-lg': 'text-2xl font-bold',
+};
+
+const colorClasses: Record<TextColor, string> = {
+  primary: 'text-[var(--text-primary)]',
+  secondary: 'text-[var(--text-secondary)]',
+  muted: 'text-[var(--text-muted)]',
+  inverse: 'text-[var(--text-inverse)]',
+};
+
+export function Text({
+  variant = 'body',
+  color = 'primary',
+  as: Component = 'p',
+  children,
+  className = '',
+  id,
+  htmlFor,
+}: TextProps) {
+  const variantClass = variantClasses[variant];
+  const colorClass = colorClasses[color];
+
+  return (
+    <Component
+      id={id}
+      className={`${variantClass} ${colorClass} ${className}`}
+      htmlFor={htmlFor}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/app/frontend/components/ui/atoms/Text/index.ts
+++ b/app/frontend/components/ui/atoms/Text/index.ts
@@ -1,0 +1,2 @@
+export { Text } from './Text';
+export type { TextProps } from './Text';

--- a/app/frontend/components/ui/atoms/index.ts
+++ b/app/frontend/components/ui/atoms/index.ts
@@ -1,0 +1,8 @@
+export { Button } from './Button';
+export type { ButtonProps } from './Button';
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeVariant } from './Badge';
+export { Input } from './Input';
+export type { InputProps } from './Input';
+export { Text } from './Text';
+export type { TextProps } from './Text';

--- a/app/frontend/components/ui/index.ts
+++ b/app/frontend/components/ui/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Gatherraa Design System – shared component library
+ * Atomic design: atoms → molecules → organisms (in app)
+ */
+
+export * from './atoms';
+export * from './molecules';

--- a/app/frontend/components/ui/molecules/Card/Card.stories.tsx
+++ b/app/frontend/components/ui/molecules/Card/Card.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card, CardHeader, CardContent, CardFooter } from './Card';
+import { Button } from '@/components/ui/atoms/Button';
+import { Text } from '@/components/ui/atoms/Text';
+
+const meta: Meta<typeof Card> = {
+  title: 'Design System/Molecules/Card',
+  component: Card,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Simple: Story = {
+  args: {
+    title: 'Card title',
+    children: (
+      <>
+        <CardContent>
+          <Text variant="body" color="secondary">
+            Card body content goes here.
+          </Text>
+        </CardContent>
+      </>
+    ),
+  },
+};
+
+export const WithHeaderAndFooter: Story = {
+  render: () => (
+    <Card title="Proposal" titleAs="h2">
+      <CardHeader>
+        <Text variant="heading-sm">Proposal Title</Text>
+        <Text variant="caption" color="muted">
+          Created 2 days ago
+        </Text>
+      </CardHeader>
+      <CardContent>
+        <Text variant="body" color="secondary">
+          Description and details of the proposal. This is example content for
+          the card body.
+        </Text>
+      </CardContent>
+      <CardFooter>
+        <div className="flex gap-2">
+          <Button variant="primary" size="sm">
+            View
+          </Button>
+          <Button variant="secondary" size="sm">
+            Cancel
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+export const WithoutTitle: Story = {
+  render: () => (
+    <Card>
+      <CardContent>
+        <Text variant="body">Card without a visible title (use for decorative cards).</Text>
+      </CardContent>
+    </Card>
+  ),
+};

--- a/app/frontend/components/ui/molecules/Card/Card.tsx
+++ b/app/frontend/components/ui/molecules/Card/Card.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import { Text } from '@/components/ui/atoms/Text';
+
+export interface CardProps {
+  children: React.ReactNode;
+  className?: string;
+  /** Optional card title (accessible heading) */
+  title?: string;
+  /** Optional title element level for semantics */
+  titleAs?: 'h2' | 'h3' | 'h4';
+}
+
+export function Card({ children, className = '', title, titleAs = 'h3' }: CardProps) {
+  const base =
+    'bg-[var(--surface)] rounded-lg shadow-[var(--shadow-sm)] border border-[var(--border-default)] overflow-hidden';
+  return (
+    <section className={`${base} ${className}`} aria-labelledby={title ? 'card-title' : undefined}>
+      {title && (
+        <Text as={titleAs} variant="heading-sm" id="card-title" className="px-4 sm:px-6 pt-4 sm:pt-6 pb-2">
+          {title}
+        </Text>
+      )}
+      {children}
+    </section>
+  );
+}
+
+export interface CardHeaderProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CardHeader({ children, className = '' }: CardHeaderProps) {
+  return <div className={`p-4 sm:p-6 ${className}`}>{children}</div>;
+}
+
+export interface CardContentProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CardContent({ children, className = '' }: CardContentProps) {
+  return <div className={`px-4 sm:px-6 pb-4 sm:pb-6 ${className}`}>{children}</div>;
+}
+
+export interface CardFooterProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function CardFooter({ children, className = '' }: CardFooterProps) {
+  return (
+    <div
+      className={`px-4 sm:px-6 py-4 border-t border-[var(--border-default)] ${className}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/frontend/components/ui/molecules/Card/index.ts
+++ b/app/frontend/components/ui/molecules/Card/index.ts
@@ -1,0 +1,2 @@
+export { Card, CardHeader, CardContent, CardFooter } from './Card';
+export type { CardProps, CardHeaderProps, CardContentProps, CardFooterProps } from './Card';

--- a/app/frontend/components/ui/molecules/FormField/FormField.stories.tsx
+++ b/app/frontend/components/ui/molecules/FormField/FormField.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FormField } from './FormField';
+
+const meta: Meta<typeof FormField> = {
+  title: 'Design System/Molecules/FormField',
+  component: FormField,
+  tags: ['autodocs'],
+  argTypes: {
+    required: { control: 'boolean' },
+    error: { control: 'text' },
+    hint: { control: 'text' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FormField>;
+
+export const Default: Story = {
+  args: {
+    label: 'Email',
+    name: 'email',
+    inputProps: {
+      type: 'email',
+      placeholder: 'you@example.com',
+    },
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Username',
+    name: 'username',
+    required: true,
+    inputProps: {
+      placeholder: 'Enter username',
+    },
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Password',
+    name: 'password',
+    required: true,
+    error: 'Password must be at least 8 characters',
+    inputProps: {
+      type: 'password',
+      placeholder: '••••••••',
+    },
+  },
+};
+
+export const WithHint: Story = {
+  args: {
+    label: 'Display name',
+    name: 'displayName',
+    hint: 'This will be visible to other users.',
+    inputProps: {
+      placeholder: 'Your name',
+    },
+  },
+};

--- a/app/frontend/components/ui/molecules/FormField/FormField.tsx
+++ b/app/frontend/components/ui/molecules/FormField/FormField.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React from 'react';
+import { Text } from '@/components/ui/atoms/Text';
+import { Input } from '@/components/ui/atoms/Input';
+
+export interface FormFieldProps {
+  label: string;
+  name: string;
+  required?: boolean;
+  error?: string;
+  hint?: string;
+  children?: React.ReactNode;
+  /** When children is not used, renders an Input with spread inputProps */
+  inputProps?: React.ComponentProps<typeof Input>;
+}
+
+export function FormField({
+  label,
+  name,
+  required,
+  error,
+  hint,
+  children,
+  inputProps,
+}: FormFieldProps) {
+  const id = `field-${name}`;
+  const errorId = error ? `${id}-error` : undefined;
+  const hintId = hint ? `${id}-hint` : undefined;
+
+  return (
+    <div className="space-y-1">
+      <Text
+        as="label"
+        variant="label"
+        color="primary"
+        htmlFor={children ? undefined : id}
+        id={`${id}-label`}
+        className="block"
+      >
+        {label}
+        {required && (
+          <span className="text-[var(--color-error)] ml-0.5" aria-hidden>
+            *
+          </span>
+        )}
+      </Text>
+      {children ? (
+        (() => {
+          if (React.isValidElement(children) && typeof children.type !== 'string') {
+            const child = children as React.ReactElement<{ id?: string; 'aria-describedby'?: string; 'aria-invalid'?: boolean }>;
+            return React.cloneElement(child, {
+              id: child.props.id ?? id,
+              'aria-describedby': [errorId, hintId].filter(Boolean).join(' ') || undefined,
+              'aria-invalid': !!error,
+            });
+          }
+          return children;
+        })()
+      ) : (
+        <Input
+          id={id}
+          name={name}
+          aria-describedby={[errorId, hintId].filter(Boolean).join(' ') || undefined}
+          aria-invalid={!!error}
+          error={!!error}
+          fullWidth
+          {...inputProps}
+        />
+      )}
+      {error && (
+        <Text
+          as="p"
+          variant="caption"
+          color="primary"
+          id={errorId}
+          className="text-[var(--color-error)]"
+          role="alert"
+        >
+          {error}
+        </Text>
+      )}
+      {hint && !error && (
+        <Text as="p" variant="caption" color="muted" id={hintId}>
+          {hint}
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/components/ui/molecules/FormField/index.ts
+++ b/app/frontend/components/ui/molecules/FormField/index.ts
@@ -1,0 +1,2 @@
+export { FormField } from './FormField';
+export type { FormFieldProps } from './FormField';

--- a/app/frontend/components/ui/molecules/StarRating/StarRating.stories.tsx
+++ b/app/frontend/components/ui/molecules/StarRating/StarRating.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { StarRating } from './StarRating';
+
+const meta: Meta<typeof StarRating> = {
+  title: 'Design System/Molecules/StarRating',
+  component: StarRating,
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: { type: 'number', min: 0, max: 5, step: 0.5 } },
+    size: { control: 'select', options: ['sm', 'md', 'lg'] },
+    interactive: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StarRating>;
+
+export const Display: Story = {
+  args: {
+    value: 4,
+    'aria-label': 'Rating: 4 out of 5 stars',
+  },
+};
+
+export const HalfStar: Story = {
+  args: {
+    value: 3.5,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <div>
+        <span className="text-sm text-[var(--text-muted)] block mb-1">Small</span>
+        <StarRating value={4} size="sm" />
+      </div>
+      <div>
+        <span className="text-sm text-[var(--text-muted)] block mb-1">Medium</span>
+        <StarRating value={4} size="md" />
+      </div>
+      <div>
+        <span className="text-sm text-[var(--text-muted)] block mb-1">Large</span>
+        <StarRating value={4} size="lg" />
+      </div>
+    </div>
+  ),
+};
+
+export const Interactive: Story = {
+  args: {
+    value: 0,
+    interactive: true,
+    onChange: (v) => console.log('Selected:', v),
+    'aria-label': 'Rate from 1 to 5 stars',
+  },
+};

--- a/app/frontend/components/ui/molecules/StarRating/StarRating.tsx
+++ b/app/frontend/components/ui/molecules/StarRating/StarRating.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import React from 'react';
+import { Star } from 'lucide-react';
+
+export interface StarRatingProps {
+  /** Value 0–5 (can be fractional for display) */
+  value: number;
+  /** Total number of stars */
+  max?: number;
+  /** Size: small (icons 4), medium (5), large (8) */
+  size?: 'sm' | 'md' | 'lg';
+  /** Show as interactive (e.g. for form input) */
+  interactive?: boolean;
+  /** Callback when star is clicked (interactive only) */
+  onChange?: (value: number) => void;
+  /** Optional label for accessibility */
+  'aria-label'?: string;
+}
+
+const sizeClasses = {
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-8 h-8',
+};
+
+export function StarRating({
+  value,
+  max = 5,
+  size = 'md',
+  interactive = false,
+  onChange,
+  'aria-label': ariaLabel,
+}: StarRatingProps) {
+  const iconClass = sizeClasses[size];
+  const filledColor = 'fill-[#facc15] text-[#facc15]'; // amber-400
+  const emptyColor =
+    'fill-[var(--gray-300)] text-[var(--gray-300)] dark:fill-[var(--gray-600)] dark:text-[var(--gray-600)]';
+
+  const content = (
+    <span
+      className="inline-flex items-center gap-0.5"
+      role={interactive ? 'group' : 'img'}
+      aria-label={ariaLabel ?? (interactive ? undefined : `Rating: ${value} out of ${max} stars`)}
+    >
+      {Array.from({ length: max }, (_, i) => {
+        const starValue = i + 1;
+        const isFilled = value >= starValue;
+        if (interactive && onChange) {
+          return (
+            <button
+              key={starValue}
+              type="button"
+              onClick={() => onChange(starValue)}
+              className={`focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-1 rounded p-0.5 ${iconClass}`}
+              aria-label={`${starValue} star${starValue !== 1 ? 's' : ''}`}
+            >
+              <Star
+                className={`${iconClass} transition-colors ${isFilled ? filledColor : emptyColor}`}
+              />
+            </button>
+          );
+        }
+        return (
+          <Star
+            key={starValue}
+            className={`${iconClass} ${isFilled ? filledColor : emptyColor}`}
+            aria-hidden
+          />
+        );
+      })}
+    </span>
+  );
+
+  return content;
+}

--- a/app/frontend/components/ui/molecules/StarRating/index.ts
+++ b/app/frontend/components/ui/molecules/StarRating/index.ts
@@ -1,0 +1,2 @@
+export { StarRating } from './StarRating';
+export type { StarRatingProps } from './StarRating';

--- a/app/frontend/components/ui/molecules/index.ts
+++ b/app/frontend/components/ui/molecules/index.ts
@@ -1,0 +1,6 @@
+export { Card, CardHeader, CardContent, CardFooter } from './Card';
+export type { CardProps } from './Card';
+export { FormField } from './FormField';
+export type { FormFieldProps } from './FormField';
+export { StarRating } from './StarRating';
+export type { StarRatingProps } from './StarRating';

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -27,6 +29,12 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@storybook/addon-a11y": "^8.4.7",
+    "@storybook/addon-essentials": "^8.4.7",
+    "@storybook/nextjs": "^8.4.7",
+    "@storybook/react": "^8.4.7",
+    "@storybook/test": "^8.4.7",
+    "storybook": "^8.4.7"
   }
 }


### PR DESCRIPTION
   Closes #104

   ## Summary
   - **Token-based theming** in `app/globals.css` (surfaces, semantic colors, typography, spacing, radius; dark mode).
   - **Atomic UI library** under `components/ui/`: atoms (Button, Badge, Input, Text), molecules (Card, FormField, StarRating).
   - **Storybook** with a11y addon and stories for all design system components.
   - **Accessibility**: focus-visible styles, ARIA where needed, a11y addon in Storybook.
   - **Refactor**: StatusBadge now uses the design system Badge.

   ## How to verify
   - `cd app/frontend && npm install && npm run storybook` — open Design System stories and Accessibility tab.
   - DAO proposal cards still show status badges (now using shared Badge).