### PR TITLE
feat(frontend): add DynamicVideoGrid, VideoPlayerSync, and RealTimeRecommendations

### DIFF
--- a/app/frontend/app/globals.css
+++ b/app/frontend/app/globals.css
@@ -180,6 +180,54 @@ body {
   outline-offset: var(--focus-outline-offset);
 }
 
+@keyframes video-grid-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes recommendation-enter {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes recommendation-exit {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+}
+
+.animate-recommendation-enter {
+  animation: recommendation-enter 260ms ease-out both;
+}
+
+.animate-recommendation-exit {
+  animation: recommendation-exit 220ms ease-in forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-recommendation-enter,
+  .animate-recommendation-exit {
+    animation: none !important;
+  }
+}
+
 @keyframes button-ripple {
   from {
     transform: scale(0);

--- a/app/frontend/components/video/DynamicVideoGrid.tsx
+++ b/app/frontend/components/video/DynamicVideoGrid.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { VideoGridConfig, VideoItem } from './types';
+
+export interface DynamicVideoGridProps {
+  videos: VideoItem[];
+  onVideoSelect: (video: VideoItem) => void;
+  gridConfig?: VideoGridConfig;
+  className?: string;
+  emptyMessage?: string;
+}
+
+const defaultGridConfig: Required<VideoGridConfig> = {
+  containerHeight: '70vh',
+  gap: 16,
+  rowHeight: 290,
+  overscanRows: 2,
+  minColumnWidth: 240,
+  mobileColumns: 1,
+  tabletColumns: 2,
+  desktopColumns: 4,
+  mobileBreakpoint: 768,
+  desktopBreakpoint: 1200,
+  animateCards: true,
+};
+
+const getCssSize = (value: number | string) => (typeof value === 'number' ? `${value}px` : value);
+
+export function DynamicVideoGrid({
+  videos,
+  onVideoSelect,
+  gridConfig,
+  className = '',
+  emptyMessage = 'No videos to display.',
+}: DynamicVideoGridProps) {
+  const config = useMemo(
+    () => ({ ...defaultGridConfig, ...gridConfig }),
+    [gridConfig],
+  );
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const updateSize = () => {
+      setContainerWidth(container.clientWidth);
+      setViewportHeight(container.clientHeight);
+    };
+
+    updateSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateSize);
+      return () => {
+        window.removeEventListener('resize', updateSize);
+      };
+    }
+
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(container);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  const layout = useMemo(() => {
+    const width = Math.max(1, containerWidth);
+    const maxColumnsByWidth = Math.max(
+      1,
+      Math.floor((width + config.gap) / (config.minColumnWidth + config.gap)),
+    );
+    const preferredColumns =
+      width < config.mobileBreakpoint
+        ? config.mobileColumns
+        : width < config.desktopBreakpoint
+          ? config.tabletColumns
+          : config.desktopColumns;
+    const columns = Math.max(1, Math.min(preferredColumns, maxColumnsByWidth));
+    const cardWidth = (width - config.gap * (columns - 1)) / columns;
+    const rowCount = Math.ceil(videos.length / columns);
+    const totalHeight = rowCount * config.rowHeight;
+    const safeViewportHeight = viewportHeight > 0 ? viewportHeight : config.rowHeight * 3;
+
+    if (rowCount === 0) {
+      return {
+        columns,
+        cardWidth,
+        cardHeight: config.rowHeight - config.gap,
+        rowCount,
+        totalHeight: 0,
+        visibleStartIndex: 0,
+        visibleEndIndex: -1,
+      };
+    }
+
+    const startRow = Math.max(
+      0,
+      Math.floor(scrollTop / config.rowHeight) - config.overscanRows,
+    );
+    const endRow = Math.min(
+      rowCount - 1,
+      Math.ceil((scrollTop + safeViewportHeight) / config.rowHeight) + config.overscanRows,
+    );
+
+    return {
+      columns,
+      cardWidth,
+      cardHeight: config.rowHeight - config.gap,
+      rowCount,
+      totalHeight,
+      visibleStartIndex: startRow * columns,
+      visibleEndIndex: Math.min(videos.length - 1, (endRow + 1) * columns - 1),
+    };
+  }, [config, containerWidth, scrollTop, videos.length, viewportHeight]);
+
+  const visibleVideos = useMemo(() => {
+    if (layout.visibleEndIndex < layout.visibleStartIndex) {
+      return [];
+    }
+    return videos.slice(layout.visibleStartIndex, layout.visibleEndIndex + 1);
+  }, [layout.visibleEndIndex, layout.visibleStartIndex, videos]);
+
+  if (videos.length === 0) {
+    return (
+      <div
+        className={`rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-8 text-center text-[var(--text-secondary)] ${className}`.trim()}
+      >
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative overflow-auto rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4 ${className}`.trim()}
+      style={{ height: getCssSize(config.containerHeight) }}
+      onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+      role="list"
+      aria-label="Video grid"
+    >
+      <div
+        className="relative"
+        style={{
+          height: `${layout.totalHeight}px`,
+          minHeight: `${Math.max(layout.rowCount, 1) * config.rowHeight}px`,
+        }}
+      >
+        {visibleVideos.map((video, visibleIndex) => {
+          const index = layout.visibleStartIndex + visibleIndex;
+          const row = Math.floor(index / layout.columns);
+          const column = index % layout.columns;
+          const left = column * (layout.cardWidth + config.gap);
+          const top = row * config.rowHeight;
+
+          return (
+            <article
+              key={video.id}
+              role="listitem"
+              className="absolute"
+              style={{
+                left,
+                top,
+                width: layout.cardWidth,
+                height: layout.cardHeight,
+                contain: 'layout paint style',
+                animation: config.animateCards
+                  ? 'video-grid-card-enter 320ms cubic-bezier(0.18, 0.9, 0.32, 1) both'
+                  : undefined,
+                animationDelay: config.animateCards
+                  ? `${Math.min(220, (index % layout.columns) * 35)}ms`
+                  : undefined,
+              }}
+            >
+              <button
+                type="button"
+                className="group flex h-full w-full flex-col overflow-hidden rounded-xl border border-[var(--border-default)] bg-[var(--surface)] text-left shadow-sm transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)]"
+                onClick={() => onVideoSelect(video)}
+                aria-label={`Open video: ${video.title}`}
+              >
+                <div className="relative h-0 w-full overflow-hidden bg-[var(--border-muted)] pt-[56.25%]">
+                  {video.thumbnailUrl ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img
+                      src={video.thumbnailUrl}
+                      alt={video.title}
+                      loading="lazy"
+                      decoding="async"
+                      className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03]"
+                    />
+                  ) : (
+                    <div className="absolute inset-0 flex items-center justify-center text-sm text-[var(--text-muted)]">
+                      No thumbnail
+                    </div>
+                  )}
+                  {video.durationLabel && (
+                    <span className="absolute bottom-2 right-2 rounded bg-black/75 px-2 py-0.5 text-xs font-medium text-white">
+                      {video.durationLabel}
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-1 flex-col gap-1 px-3 py-3">
+                  <h3 className="line-clamp-2 text-sm font-semibold text-[var(--text-primary)]">
+                    {video.title}
+                  </h3>
+                  {video.creatorName && (
+                    <p className="truncate text-xs text-[var(--text-secondary)]">
+                      {video.creatorName}
+                    </p>
+                  )}
+                  <p className="truncate text-xs text-[var(--text-muted)]">
+                    {[video.viewsLabel, video.publishedLabel]
+                      .filter(Boolean)
+                      .join(' | ')}
+                  </p>
+                </div>
+              </button>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/components/video/RealTimeRecommendations.tsx
+++ b/app/frontend/components/video/RealTimeRecommendations.tsx
@@ -1,0 +1,536 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { RecommendationItem, RecommendationResponse } from './types';
+
+type RecommendationPhase = 'idle' | 'entering' | 'exiting';
+
+interface AnimatedRecommendation {
+  video: RecommendationItem;
+  phase: RecommendationPhase;
+}
+
+export interface RealTimeRecommendationsProps {
+  currentVideoId: string;
+  onVideoSelect: (video: RecommendationItem) => void;
+  className?: string;
+  title?: string;
+  apiEndpoint?: string;
+  wsEndpoint?: string;
+  pollIntervalMs?: number;
+  maxItems?: number;
+  itemHeight?: number;
+  initialRecommendations?: RecommendationItem[];
+}
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
+const DEFAULT_API_ENDPOINT = '/videos/:videoId/recommendations';
+const DEFAULT_WS_ENDPOINT =
+  process.env.NEXT_PUBLIC_RECOMMENDATIONS_WS_URL || '';
+
+function replaceVideoIdToken(template: string, currentVideoId: string) {
+  return template.replace(':videoId', encodeURIComponent(currentVideoId));
+}
+
+function normalizeRecommendation(
+  item: unknown,
+  index: number,
+): RecommendationItem | null {
+  if (!item || typeof item !== 'object') {
+    return null;
+  }
+
+  const candidate = item as Record<string, unknown>;
+  const titleValue = candidate.title ?? candidate.name;
+  const fallbackId = `${String(titleValue ?? 'video')}-${index}`;
+  const idValue = candidate.id ?? candidate.videoId ?? candidate.slug ?? fallbackId;
+  const title = String(titleValue ?? 'Untitled video');
+
+  return {
+    id: String(idValue),
+    title,
+    thumbnailUrl: typeof candidate.thumbnailUrl === 'string'
+      ? candidate.thumbnailUrl
+      : typeof candidate.thumbnail === 'string'
+        ? candidate.thumbnail
+        : typeof candidate.imageUrl === 'string'
+          ? candidate.imageUrl
+          : undefined,
+    videoUrl: typeof candidate.videoUrl === 'string'
+      ? candidate.videoUrl
+      : typeof candidate.url === 'string'
+        ? candidate.url
+        : undefined,
+    creatorName: typeof candidate.creatorName === 'string'
+      ? candidate.creatorName
+      : typeof candidate.channelName === 'string'
+        ? candidate.channelName
+        : typeof candidate.author === 'string'
+          ? candidate.author
+          : undefined,
+    description: typeof candidate.description === 'string'
+      ? candidate.description
+      : undefined,
+    durationLabel: typeof candidate.durationLabel === 'string'
+      ? candidate.durationLabel
+      : typeof candidate.duration === 'string'
+        ? candidate.duration
+        : undefined,
+    viewsLabel: typeof candidate.viewsLabel === 'string'
+      ? candidate.viewsLabel
+      : typeof candidate.views === 'number'
+        ? `${candidate.views.toLocaleString()} views`
+        : undefined,
+    publishedLabel: typeof candidate.publishedLabel === 'string'
+      ? candidate.publishedLabel
+      : typeof candidate.publishedAt === 'string'
+        ? candidate.publishedAt
+        : undefined,
+    reasonLabel: typeof candidate.reasonLabel === 'string'
+      ? candidate.reasonLabel
+      : typeof candidate.reason === 'string'
+        ? candidate.reason
+        : undefined,
+    score: typeof candidate.score === 'number' ? candidate.score : undefined,
+  };
+}
+
+function extractRecommendations(payload: unknown): RecommendationItem[] {
+  if (Array.isArray(payload)) {
+    return payload
+      .map((item, index) => normalizeRecommendation(item, index))
+      .filter((item): item is RecommendationItem => Boolean(item));
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+
+  const source = payload as RecommendationResponse & {
+    items?: unknown[];
+    type?: string;
+  };
+
+  const nested = source.data ?? source.recommendations ?? source.items;
+  if (Array.isArray(nested)) {
+    return nested
+      .map((item, index) => normalizeRecommendation(item, index))
+      .filter((item): item is RecommendationItem => Boolean(item));
+  }
+
+  return [];
+}
+
+function isRecommendationPayload(payload: unknown): boolean {
+  if (Array.isArray(payload)) {
+    return true;
+  }
+  if (!payload || typeof payload !== 'object') {
+    return false;
+  }
+
+  const candidate = payload as Record<string, unknown>;
+  if (
+    Array.isArray(candidate.data) ||
+    Array.isArray(candidate.recommendations) ||
+    Array.isArray(candidate.items)
+  ) {
+    return true;
+  }
+
+  return (
+    candidate.type === 'recommendations' ||
+    candidate.type === 'video_recommendations'
+  );
+}
+
+function buildApiUrl(apiEndpoint: string, currentVideoId: string) {
+  const resolvedEndpoint = replaceVideoIdToken(apiEndpoint, currentVideoId);
+  if (resolvedEndpoint.startsWith('http://') || resolvedEndpoint.startsWith('https://')) {
+    return resolvedEndpoint;
+  }
+  return `${API_BASE_URL}${resolvedEndpoint.startsWith('/') ? '' : '/'}${resolvedEndpoint}`;
+}
+
+function normalizeWsUrl(template: string, currentVideoId: string): string | null {
+  const replaced = replaceVideoIdToken(template, currentVideoId);
+  let absolute = replaced;
+
+  if (absolute.startsWith('/')) {
+    try {
+      const apiUrl = new URL(API_BASE_URL);
+      const wsProtocol = apiUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+      absolute = `${wsProtocol}//${apiUrl.host}${absolute}`;
+    } catch {
+      return null;
+    }
+  } else if (absolute.startsWith('http://')) {
+    absolute = absolute.replace('http://', 'ws://');
+  } else if (absolute.startsWith('https://')) {
+    absolute = absolute.replace('https://', 'wss://');
+  }
+
+  try {
+    const parsed = new URL(absolute);
+    if (!template.includes(':videoId')) {
+      parsed.searchParams.set('videoId', currentVideoId);
+    }
+    return parsed.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function RealTimeRecommendations({
+  currentVideoId,
+  onVideoSelect,
+  className = '',
+  title = 'Recommended next',
+  apiEndpoint = DEFAULT_API_ENDPOINT,
+  wsEndpoint = DEFAULT_WS_ENDPOINT,
+  pollIntervalMs = 30000,
+  maxItems = 8,
+  itemHeight = 96,
+  initialRecommendations = [],
+}: RealTimeRecommendationsProps) {
+  const [items, setItems] = useState<AnimatedRecommendation[]>(
+    initialRecommendations.slice(0, maxItems).map((video) => ({
+      video,
+      phase: 'idle',
+    })),
+  );
+  const [loading, setLoading] = useState(initialRecommendations.length === 0);
+  const [error, setError] = useState<string | null>(null);
+  const [wsConnected, setWsConnected] = useState(false);
+  const phaseCleanupTimerRef = useRef<number | null>(null);
+  const wsReconnectTimerRef = useRef<number | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const fetchRequestRef = useRef(0);
+
+  const displayMinHeight = useMemo(() => {
+    const reservedRows = Math.min(maxItems, 4);
+    return reservedRows * itemHeight + Math.max(reservedRows - 1, 0) * 8;
+  }, [itemHeight, maxItems]);
+
+  const applyRecommendations = useCallback(
+    (nextRecommendations: RecommendationItem[]) => {
+      const next = nextRecommendations.slice(0, maxItems);
+
+      setItems((previousItems) => {
+        const previousById = new Map(
+          previousItems.map((item) => [item.video.id, item]),
+        );
+        const nextIds = new Set(next.map((video) => video.id));
+
+        const merged: AnimatedRecommendation[] = next.map((video) => {
+          const existing = previousById.get(video.id);
+          return {
+            video,
+            phase:
+              existing && existing.phase !== 'exiting' ? 'idle' : 'entering',
+          };
+        });
+
+        for (const previous of previousItems) {
+          if (!nextIds.has(previous.video.id)) {
+            merged.push({
+              video: previous.video,
+              phase: 'exiting',
+            });
+          }
+        }
+
+        return merged;
+      });
+
+      setError(null);
+      setLoading(false);
+    },
+    [maxItems],
+  );
+
+  const fetchRecommendations = useCallback(async () => {
+    const requestId = fetchRequestRef.current + 1;
+    fetchRequestRef.current = requestId;
+
+    if (!currentVideoId) {
+      setItems([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const requestUrl = buildApiUrl(apiEndpoint, currentVideoId);
+      const response = await fetch(requestUrl, {
+        method: 'GET',
+        credentials: 'include',
+        cache: 'no-store',
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed with status ${response.status}`);
+      }
+
+      const payload = (await response.json()) as unknown;
+      if (requestId !== fetchRequestRef.current) {
+        return;
+      }
+      applyRecommendations(extractRecommendations(payload));
+    } catch (fetchError) {
+      if (requestId !== fetchRequestRef.current) {
+        return;
+      }
+      setLoading(false);
+      setError(
+        fetchError instanceof Error
+          ? fetchError.message
+          : 'Could not fetch recommendations.',
+      );
+    }
+  }, [apiEndpoint, applyRecommendations, currentVideoId]);
+
+  useEffect(() => {
+    void fetchRecommendations();
+  }, [fetchRecommendations]);
+
+  useEffect(() => {
+    if (pollIntervalMs <= 0) {
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      void fetchRecommendations();
+    }, pollIntervalMs);
+
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [fetchRecommendations, pollIntervalMs]);
+
+  useEffect(() => {
+    if (phaseCleanupTimerRef.current) {
+      window.clearTimeout(phaseCleanupTimerRef.current);
+      phaseCleanupTimerRef.current = null;
+    }
+
+    const hasTransientItems = items.some(
+      (item) => item.phase === 'entering' || item.phase === 'exiting',
+    );
+    if (!hasTransientItems) {
+      return;
+    }
+
+    phaseCleanupTimerRef.current = window.setTimeout(() => {
+      setItems((previous) =>
+        previous
+          .filter((item) => item.phase !== 'exiting')
+          .map((item) =>
+            item.phase === 'entering' ? { ...item, phase: 'idle' } : item,
+          ),
+      );
+      phaseCleanupTimerRef.current = null;
+    }, 280);
+
+    return () => {
+      if (phaseCleanupTimerRef.current) {
+        window.clearTimeout(phaseCleanupTimerRef.current);
+        phaseCleanupTimerRef.current = null;
+      }
+    };
+  }, [items]);
+
+  useEffect(() => {
+    if (!wsEndpoint || !currentVideoId) {
+      return;
+    }
+
+    const wsUrl = normalizeWsUrl(wsEndpoint, currentVideoId);
+    if (!wsUrl) {
+      return;
+    }
+
+    let isActive = true;
+    let retryAttempt = 0;
+
+    const connect = () => {
+      if (!isActive) {
+        return;
+      }
+
+      const socket = new WebSocket(wsUrl);
+      wsRef.current = socket;
+
+      socket.addEventListener('open', () => {
+        if (!isActive) {
+          return;
+        }
+        retryAttempt = 0;
+        setWsConnected(true);
+        socket.send(
+          JSON.stringify({
+            type: 'subscribe_recommendations',
+            videoId: currentVideoId,
+          }),
+        );
+      });
+
+      socket.addEventListener('message', (event) => {
+        if (!isActive) {
+          return;
+        }
+
+        try {
+          const parsed = JSON.parse(event.data) as unknown;
+          if (isRecommendationPayload(parsed)) {
+            const next = extractRecommendations(parsed);
+            applyRecommendations(next);
+          }
+        } catch {
+          // Ignore malformed websocket payloads.
+        }
+      });
+
+      socket.addEventListener('close', () => {
+        if (!isActive) {
+          return;
+        }
+
+        setWsConnected(false);
+        if (retryAttempt >= 4) {
+          return;
+        }
+
+        const backoffMs = Math.min(8000, 1000 * 2 ** retryAttempt);
+        retryAttempt += 1;
+        wsReconnectTimerRef.current = window.setTimeout(connect, backoffMs);
+      });
+
+      socket.addEventListener('error', () => {
+        setWsConnected(false);
+      });
+    };
+
+    connect();
+
+    return () => {
+      isActive = false;
+      setWsConnected(false);
+      if (wsReconnectTimerRef.current) {
+        window.clearTimeout(wsReconnectTimerRef.current);
+        wsReconnectTimerRef.current = null;
+      }
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [applyRecommendations, currentVideoId, wsEndpoint]);
+
+  return (
+    <section
+      className={`rounded-xl border border-[var(--border-default)] bg-[var(--surface)] p-4 ${className}`.trim()}
+      aria-live="polite"
+      aria-busy={loading}
+    >
+      <header className="mb-3 flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-[var(--text-primary)]">{title}</h2>
+        <span className="inline-flex items-center gap-1 text-xs text-[var(--text-muted)]">
+          <span
+            className={`h-2 w-2 rounded-full ${wsConnected ? 'bg-green-500' : 'bg-[var(--gray-400)]'}`}
+            aria-hidden
+          />
+          {wsConnected ? 'Live' : 'Polling'}
+        </span>
+      </header>
+
+      <ul
+        className="space-y-2"
+        style={{ minHeight: `${displayMinHeight}px` }}
+        aria-label="Video recommendations"
+      >
+        {items.map((item) => (
+          <li
+            key={item.video.id}
+            style={{ height: `${itemHeight}px` }}
+            className={`overflow-hidden rounded-lg border border-[var(--border-default)] bg-[var(--surface-elevated)] ${
+              item.phase === 'entering'
+                ? 'animate-recommendation-enter'
+                : item.phase === 'exiting'
+                  ? 'animate-recommendation-exit'
+                  : ''
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onVideoSelect(item.video)}
+              className="flex h-full w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-[var(--gray-100)] dark:hover:bg-[var(--gray-800)]"
+              aria-label={`Play recommended video: ${item.video.title}`}
+            >
+              <div className="relative h-full w-28 shrink-0 overflow-hidden rounded bg-[var(--border-muted)]">
+                {item.video.thumbnailUrl ? (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={item.video.thumbnailUrl}
+                    alt={item.video.title}
+                    loading="lazy"
+                    decoding="async"
+                    className="h-full w-full object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center text-[10px] text-[var(--text-muted)]">
+                    No preview
+                  </div>
+                )}
+                {item.video.durationLabel && (
+                  <span className="absolute bottom-1 right-1 rounded bg-black/75 px-1.5 py-0.5 text-[10px] text-white">
+                    {item.video.durationLabel}
+                  </span>
+                )}
+              </div>
+
+              <div className="min-w-0 flex-1">
+                <h3 className="truncate text-sm font-medium text-[var(--text-primary)]">
+                  {item.video.title}
+                </h3>
+                {item.video.creatorName && (
+                  <p className="truncate text-xs text-[var(--text-secondary)]">
+                    {item.video.creatorName}
+                  </p>
+                )}
+                <p className="truncate text-xs text-[var(--text-muted)]">
+                  {[item.video.viewsLabel, item.video.publishedLabel]
+                    .filter(Boolean)
+                    .join(' | ')}
+                </p>
+                {item.video.reasonLabel && (
+                  <p className="truncate text-xs text-[var(--color-primary)]">
+                    {item.video.reasonLabel}
+                  </p>
+                )}
+              </div>
+            </button>
+          </li>
+        ))}
+
+        {loading &&
+          items.length === 0 &&
+          Array.from({ length: Math.min(maxItems, 4) }).map((_, index) => (
+            <li
+              key={`recommendation-skeleton-${index}`}
+              style={{ height: `${itemHeight}px` }}
+              className="animate-pulse rounded-lg border border-[var(--border-default)] bg-[var(--surface-elevated)]"
+              aria-hidden
+            />
+          ))}
+      </ul>
+
+      {error && (
+        <p className="mt-3 text-xs text-[var(--color-error)]">
+          Failed to refresh recommendations: {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/frontend/components/video/VideoPlayerSync.tsx
+++ b/app/frontend/components/video/VideoPlayerSync.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import React, {
+  ForwardedRef,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
+
+export interface PersistedPlaybackState {
+  currentTime: number;
+  duration: number | null;
+  paused: boolean;
+  volume: number;
+  muted: boolean;
+  playbackRate: number;
+  updatedAt: number;
+}
+
+export interface VideoPlayerSyncProps
+  extends React.VideoHTMLAttributes<HTMLVideoElement> {
+  videoId: string;
+  persistKey?: string;
+  storageScope?: 'session' | 'local';
+  autoResume?: boolean;
+  syncIntervalMs?: number;
+  clearOnEnded?: boolean;
+  onPlaybackStateChange?: (state: PersistedPlaybackState) => void;
+}
+
+function assignRef(
+  ref: ForwardedRef<HTMLVideoElement>,
+  value: HTMLVideoElement | null,
+) {
+  if (typeof ref === 'function') {
+    ref(value);
+    return;
+  }
+  if (ref) {
+    ref.current = value;
+  }
+}
+
+export const VideoPlayerSync = forwardRef<HTMLVideoElement, VideoPlayerSyncProps>(
+  (
+    {
+      videoId,
+      persistKey,
+      storageScope = 'session',
+      autoResume = true,
+      syncIntervalMs = 1000,
+      clearOnEnded = false,
+      onPlaybackStateChange,
+      controls = true,
+      className = '',
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const localVideoRef = useRef<HTMLVideoElement | null>(null);
+    const lastTimeSyncRef = useRef(0);
+    const storageKey = useMemo(
+      () => persistKey ?? `gatheraa:video-playback:${videoId}`,
+      [persistKey, videoId],
+    );
+
+    const getStorage = useCallback(() => {
+      if (typeof window === 'undefined') {
+        return null;
+      }
+      return storageScope === 'local'
+        ? window.localStorage
+        : window.sessionStorage;
+    }, [storageScope]);
+
+    const readState = useCallback((): PersistedPlaybackState | null => {
+      const storage = getStorage();
+      if (!storage) {
+        return null;
+      }
+      try {
+        const raw = storage.getItem(storageKey);
+        if (!raw) {
+          return null;
+        }
+        return JSON.parse(raw) as PersistedPlaybackState;
+      } catch {
+        return null;
+      }
+    }, [getStorage, storageKey]);
+
+    const removeState = useCallback(() => {
+      const storage = getStorage();
+      if (!storage) {
+        return;
+      }
+      try {
+        storage.removeItem(storageKey);
+      } catch {
+        // Ignore persistence failures in private mode / restricted storage.
+      }
+    }, [getStorage, storageKey]);
+
+    const persistCurrentState = useCallback(() => {
+      const videoElement = localVideoRef.current;
+      const storage = getStorage();
+      if (!videoElement || !storage) {
+        return;
+      }
+
+      const nextState: PersistedPlaybackState = {
+        currentTime: Number.isFinite(videoElement.currentTime)
+          ? videoElement.currentTime
+          : 0,
+        duration: Number.isFinite(videoElement.duration)
+          ? videoElement.duration
+          : null,
+        paused: videoElement.paused,
+        volume: videoElement.volume,
+        muted: videoElement.muted,
+        playbackRate: videoElement.playbackRate,
+        updatedAt: Date.now(),
+      };
+
+      try {
+        storage.setItem(storageKey, JSON.stringify(nextState));
+        onPlaybackStateChange?.(nextState);
+      } catch {
+        // Ignore persistence failures in private mode / restricted storage.
+      }
+    }, [getStorage, onPlaybackStateChange, storageKey]);
+
+    useEffect(() => {
+      const videoElement = localVideoRef.current;
+      if (!videoElement) {
+        return;
+      }
+
+      const restoreState = () => {
+        const savedState = readState();
+        if (!savedState) {
+          return;
+        }
+
+        if (
+          Number.isFinite(savedState.currentTime) &&
+          savedState.currentTime > 0 &&
+          Number.isFinite(videoElement.duration)
+        ) {
+          videoElement.currentTime = Math.min(
+            savedState.currentTime,
+            Math.max(0, videoElement.duration - 0.1),
+          );
+        }
+
+        videoElement.volume = savedState.volume;
+        videoElement.muted = savedState.muted;
+        videoElement.playbackRate = savedState.playbackRate;
+
+        if (autoResume && !savedState.paused) {
+          void videoElement.play().catch(() => {
+            // Browsers can block autoplay if not user-initiated.
+          });
+        }
+      };
+
+      if (videoElement.readyState >= 1) {
+        restoreState();
+      } else {
+        videoElement.addEventListener('loadedmetadata', restoreState);
+      }
+
+      return () => {
+        videoElement.removeEventListener('loadedmetadata', restoreState);
+      };
+    }, [autoResume, readState, videoId]);
+
+    useEffect(() => {
+      const videoElement = localVideoRef.current;
+      if (!videoElement) {
+        return;
+      }
+
+      const handlePlaybackEvent = (event: Event) => {
+        if (event.type === 'timeupdate') {
+          const now = Date.now();
+          if (now - lastTimeSyncRef.current < syncIntervalMs) {
+            return;
+          }
+          lastTimeSyncRef.current = now;
+        }
+
+        if (event.type === 'ended' && clearOnEnded) {
+          removeState();
+          return;
+        }
+
+        persistCurrentState();
+      };
+
+      const syncEvents: Array<keyof HTMLMediaElementEventMap> = [
+        'play',
+        'pause',
+        'timeupdate',
+        'seeking',
+        'ratechange',
+        'volumechange',
+        'ended',
+      ];
+
+      for (const eventName of syncEvents) {
+        videoElement.addEventListener(eventName, handlePlaybackEvent);
+      }
+
+      const flushOnHidden = () => {
+        if (document.visibilityState === 'hidden') {
+          persistCurrentState();
+        }
+      };
+
+      window.addEventListener('pagehide', persistCurrentState);
+      document.addEventListener('visibilitychange', flushOnHidden);
+
+      return () => {
+        for (const eventName of syncEvents) {
+          videoElement.removeEventListener(eventName, handlePlaybackEvent);
+        }
+        window.removeEventListener('pagehide', persistCurrentState);
+        document.removeEventListener('visibilitychange', flushOnHidden);
+        persistCurrentState();
+      };
+    }, [clearOnEnded, persistCurrentState, removeState, syncIntervalMs]);
+
+    return (
+      <video
+        ref={(node) => {
+          localVideoRef.current = node;
+          assignRef(forwardedRef, node);
+        }}
+        controls={controls}
+        className={`w-full rounded-xl bg-black ${className}`.trim()}
+        {...props}
+      />
+    );
+  },
+);
+
+VideoPlayerSync.displayName = 'VideoPlayerSync';
+

--- a/app/frontend/components/video/index.ts
+++ b/app/frontend/components/video/index.ts
@@ -1,0 +1,16 @@
+export { DynamicVideoGrid } from './DynamicVideoGrid';
+export type { DynamicVideoGridProps } from './DynamicVideoGrid';
+export { VideoPlayerSync } from './VideoPlayerSync';
+export type {
+  PersistedPlaybackState,
+  VideoPlayerSyncProps,
+} from './VideoPlayerSync';
+export { RealTimeRecommendations } from './RealTimeRecommendations';
+export type { RealTimeRecommendationsProps } from './RealTimeRecommendations';
+export type {
+  RecommendationItem,
+  RecommendationResponse,
+  VideoGridConfig,
+  VideoItem,
+} from './types';
+

--- a/app/frontend/components/video/types.ts
+++ b/app/frontend/components/video/types.ts
@@ -1,0 +1,36 @@
+export interface VideoItem {
+  id: string;
+  title: string;
+  thumbnailUrl?: string;
+  videoUrl?: string;
+  creatorName?: string;
+  description?: string;
+  durationLabel?: string;
+  viewsLabel?: string;
+  publishedLabel?: string;
+}
+
+export interface VideoGridConfig {
+  containerHeight?: number | string;
+  gap?: number;
+  rowHeight?: number;
+  overscanRows?: number;
+  minColumnWidth?: number;
+  mobileColumns?: number;
+  tabletColumns?: number;
+  desktopColumns?: number;
+  mobileBreakpoint?: number;
+  desktopBreakpoint?: number;
+  animateCards?: boolean;
+}
+
+export interface RecommendationItem extends VideoItem {
+  score?: number;
+  reasonLabel?: string;
+}
+
+export interface RecommendationResponse {
+  data?: RecommendationItem[];
+  recommendations?: RecommendationItem[];
+}
+


### PR DESCRIPTION
## Summary
- add DynamicVideoGrid with responsive layout, lazy thumbnails, and virtual scrolling to reduce DOM bloat
- add VideoPlayerSync to persist and restore playback state across navigation
- add RealTimeRecommendations with API polling + optional WebSocket updates and animated item transitions
- add shared video types and component barrel exports
- add motion keyframes for grid/recommendation card enter-exit transitions

## Validation
- 
px eslint components/video/DynamicVideoGrid.tsx components/video/VideoPlayerSync.tsx components/video/RealTimeRecommendations.tsx components/video/types.ts components/video/index.ts

Closes #154
Closes #155
Closes #156