### PR TITLE
refactor(contracts): extract magic numbers and strings to named const…

### DIFF
--- a/contract/dutch_auction_contract/src/lib.rs
+++ b/contract/dutch_auction_contract/src/lib.rs
@@ -24,6 +24,14 @@ use gathera_common::{
 #[contract]
 pub struct DutchAuctionContract;
 
+// ─── Dutch Auction Constants ────────────────────────────────────────────────────────
+
+/// Fixed-point precision divisor used for exponential decay calculations (1_000_000 = 100%).
+/// Decay multipliers are expressed as integers in [0, 1_000_000] where 1_000_000 means no decay.
+const DECAY_PRECISION: u64 = 1_000_000;
+/// Divisor applied before computing the decay division to prevent integer overflow.
+const DECAY_SCALE_DIVISOR: u64 = 100;
+
 #[contractimpl]
 impl DutchAuctionContract {
     pub fn initialize(env: Env, admin: Address, config: AuctionConfig) {
@@ -458,21 +466,21 @@ impl DutchAuctionContract {
         let decay_numerator = decay_factor.checked_mul(time_elapsed).expect("Arithmetic overflow");
         
         // Prevent overflow
-        if decay_numerator > 1000000 {
+        if decay_numerator > DECAY_PRECISION {
             return floor_price;
         }
 
-        let decay_div = decay_numerator.checked_div(100).expect("Arithmetic error");
-        if decay_div >= 1000000 {
+        let decay_div = decay_numerator.checked_div(DECAY_SCALE_DIVISOR).expect("Arithmetic error");
+        if decay_div >= DECAY_PRECISION {
             return floor_price;
         }
-        let decay_multiplier = 1000000 - decay_div; // Simplified decay
+        let decay_multiplier = DECAY_PRECISION - decay_div; // Simplified decay
         if decay_multiplier <= 0 {
             return floor_price;
         }
 
         let initial_floor_diff = initial_price.checked_sub(floor_price).expect("Arithmetic error");
-        let price_above_floor = initial_floor_diff.checked_mul(decay_multiplier as i128).and_then(|v| v.checked_div(1000000)).expect("Arithmetic overflow");
+        let price_above_floor = initial_floor_diff.checked_mul(decay_multiplier as i128).and_then(|v| v.checked_div(DECAY_PRECISION as i128)).expect("Arithmetic overflow");
         floor_price.checked_add(price_above_floor).expect("Arithmetic overflow")
     }
 

--- a/contract/feature_flag_contract/src/lib.rs
+++ b/contract/feature_flag_contract/src/lib.rs
@@ -21,6 +21,18 @@ use soroban_sdk::{
 #[contract]
 pub struct FeatureFlagContract;
 
+// ─── Feature Flag Constants ──────────────────────────────────────────────────────
+
+/// TTL (in ledgers) for temporary analytics data storage.
+/// At a 1-second ledger close, this corresponds to 1 hour of retention.
+const ANALYTICS_TTL_LEDGERS: u32 = 3_600;
+/// Number of seconds in one day, used for time-based rollout calculations.
+const SECONDS_PER_DAY: u64 = 86_400;
+/// Maximum valid rollout percentage (exclusive upper bound = 100%).
+const MAX_ROLLOUT_PERCENTAGE: u32 = 100;
+/// Modulus used to map a hash value to a rollout percentage bucket [0, 100).
+const ROLLOUT_HASH_MODULUS: u32 = 100;
+
 #[contractimpl]
 impl FeatureFlagContract {
     // Initialize the contract
@@ -200,7 +212,7 @@ impl FeatureFlagContract {
         let mut cumulative = 0u32;
         for (variant_id, allocation) in test.traffic_allocation.iter() {
             cumulative += allocation;
-            if hash_value % 100 < cumulative {
+            if hash_value % ROLLOUT_HASH_MODULUS < cumulative {
                 return Some(variant_id);
             }
         }
@@ -429,7 +441,7 @@ impl FeatureFlagContract {
     }
 
     fn validate_flag_inputs(_key: &Symbol, rollout_percentage: u32, _environment: &Environment) -> Result<(), FeatureFlagError> {
-        if rollout_percentage > 100 {
+        if rollout_percentage > MAX_ROLLOUT_PERCENTAGE {
             return Err(FeatureFlagError::InvalidPercentage);
         }
 
@@ -453,9 +465,9 @@ impl FeatureFlagContract {
             return Err(FeatureFlagError::InvalidTimeRange);
         }
 
-        // Validate traffic allocation sums to 100
+        // Validate traffic allocation sums to 100%
         let total: u32 = traffic_allocation.iter().map(|(_, allocation)| allocation).sum();
-        if total != 100 {
+        if total != MAX_ROLLOUT_PERCENTAGE {
             return Err(FeatureFlagError::InvalidTrafficAllocation);
         }
 
@@ -463,7 +475,7 @@ impl FeatureFlagContract {
     }
 
     fn validate_percentage(percentage: u32) -> Result<(), FeatureFlagError> {
-        if percentage > 100 {
+        if percentage > MAX_ROLLOUT_PERCENTAGE {
             return Err(FeatureFlagError::InvalidPercentage);
         }
         Ok(())
@@ -484,7 +496,7 @@ impl FeatureFlagContract {
             user_hash.as_bytes()[3],
         ]);
 
-        hash_value % 100 < flag.rollout_percentage
+        hash_value % ROLLOUT_HASH_MODULUS < flag.rollout_percentage
     }
 
     fn evaluate_segmented_rollout(e: &Env, flag: &FeatureFlag, user_segment: &UserSegment) -> bool {
@@ -502,7 +514,7 @@ impl FeatureFlagContract {
         let current_time = e.ledger().timestamp();
         
         // Simple time-based rollout (could be more sophisticated)
-        let time_factor = (current_time % 86400) * 100 / 86400; // Percentage through the day
+        let time_factor = (current_time % SECONDS_PER_DAY) * ROLLOUT_HASH_MODULUS as u64 / SECONDS_PER_DAY; // Percentage through the day
         time_factor <= flag.rollout_percentage
     }
 
@@ -516,7 +528,7 @@ impl FeatureFlagContract {
             user_hash.as_bytes()[3],
         ]);
 
-        hash_value % 100 < flag.rollout_percentage
+        hash_value % ROLLOUT_HASH_MODULUS < flag.rollout_percentage
     }
 
     fn record_analytics(
@@ -539,6 +551,6 @@ impl FeatureFlagContract {
         };
 
         // Store analytics data (in practice, this might use a different storage strategy)
-        e.storage().temporary().set(&symbol_short!("analytics"), &analytics, 3600); // 1 hour TTL
+        e.storage().temporary().set(&symbol_short!("analytics"), &analytics, ANALYTICS_TTL_LEDGERS); // 1 hour TTL
     }
 }

--- a/contract/governance_contract/src/lib.rs
+++ b/contract/governance_contract/src/lib.rs
@@ -14,6 +14,43 @@ use storage::{DataKey, Proposal, ProposalStatus, ProposalCategory, CategorySetti
 #[contract]
 pub struct GovernanceContract;
 
+// ─── Governance Category Constants ────────────────────────────────────────────
+
+/// Category index for protocol upgrade proposals.
+const CATEGORY_PROTOCOL_UPGRADE: u32 = 0;
+/// Category index for fee adjustment proposals.
+const CATEGORY_FEE_ADJUSTMENT: u32 = 1;
+/// Category index for parameter update proposals.
+const CATEGORY_PARAMETER_UPDATE: u32 = 2;
+/// Category index for emergency proposals.
+const CATEGORY_EMERGENCY: u32 = 3;
+
+/// Minimum token quorum required for a ProtocolUpgrade proposal to pass.
+const PROTOCOL_UPGRADE_QUORUM: i128 = 1000;
+/// Minimum token quorum required for a FeeAdjustment proposal to pass.
+const FEE_ADJUSTMENT_QUORUM: i128 = 500;
+/// Minimum token quorum required for a ParameterUpdate proposal to pass.
+const PARAMETER_UPDATE_QUORUM: i128 = 100;
+/// Minimum token quorum required for an Emergency proposal to pass.
+const EMERGENCY_QUORUM: i128 = 2000;
+
+/// Approval threshold (percentage) shared by ProtocolUpgrade, FeeAdjustment, and ParameterUpdate.
+const DEFAULT_APPROVAL_THRESHOLD: u32 = 50;
+/// Approval threshold (percentage) required for Emergency proposals.
+const EMERGENCY_APPROVAL_THRESHOLD: u32 = 66;
+
+/// Voting period duration (in ledgers) for ProtocolUpgrade proposals.
+const PROTOCOL_UPGRADE_PERIOD: u32 = 100;
+/// Voting period duration (in ledgers) for FeeAdjustment proposals.
+const FEE_ADJUSTMENT_PERIOD: u32 = 50;
+/// Voting period duration (in ledgers) for ParameterUpdate proposals.
+const PARAMETER_UPDATE_PERIOD: u32 = 30;
+/// Voting period duration (in ledgers) for Emergency proposals.
+const EMERGENCY_PERIOD: u32 = 20;
+
+/// Minimum governance token balance required to submit a proposal.
+const MIN_PROPOSE_POWER: i128 = 100;
+
 #[contractimpl]
 impl GovernanceContract {
     pub fn init(
@@ -33,10 +70,10 @@ impl GovernanceContract {
         env.storage().instance().set(&DataKey::ProposalCount, &0u32);
 
         // Initialize default categories
-        Self::set_category_settings(&env, 0, 1000, 50, 100); // ProtocolUpgrade
-        Self::set_category_settings(&env, 1, 500, 50, 50);   // FeeAdjustment
-        Self::set_category_settings(&env, 2, 100, 50, 30);   // ParameterUpdate
-        Self::set_category_settings(&env, 3, 2000, 66, 20);  // Emergency
+        Self::set_category_settings(&env, CATEGORY_PROTOCOL_UPGRADE, PROTOCOL_UPGRADE_QUORUM, DEFAULT_APPROVAL_THRESHOLD, PROTOCOL_UPGRADE_PERIOD);
+        Self::set_category_settings(&env, CATEGORY_FEE_ADJUSTMENT, FEE_ADJUSTMENT_QUORUM, DEFAULT_APPROVAL_THRESHOLD, FEE_ADJUSTMENT_PERIOD);
+        Self::set_category_settings(&env, CATEGORY_PARAMETER_UPDATE, PARAMETER_UPDATE_QUORUM, DEFAULT_APPROVAL_THRESHOLD, PARAMETER_UPDATE_PERIOD);
+        Self::set_category_settings(&env, CATEGORY_EMERGENCY, EMERGENCY_QUORUM, EMERGENCY_APPROVAL_THRESHOLD, EMERGENCY_PERIOD);
 
         // Emit event
         env.events().publish(
@@ -73,8 +110,7 @@ impl GovernanceContract {
         let token_client = token::Client::new(&env, &token_addr);
         let balance = token_client.balance(&proposer);
         
-        let min_propose_power = 100; // Hardcoded for now
-        if balance < min_propose_power {
+        if balance < MIN_PROPOSE_POWER {
             panic!("Insufficient tokens to propose");
         }
 

--- a/contract/storage_initialization_contract/src/lib.rs
+++ b/contract/storage_initialization_contract/src/lib.rs
@@ -21,6 +21,14 @@ use soroban_sdk::{
 #[contract]
 pub struct StorageInitializationContract;
 
+// ─── Storage Initialization Constants ────────────────────────────────────────────────
+
+/// Maximum number of initialization attempts before the contract gives up.
+const DEFAULT_MAX_RETRY_ATTEMPTS: u32 = 3;
+/// Default initialization timeout in seconds.
+/// After this many seconds, an in-progress initialization is considered stale.
+const DEFAULT_INITIALIZATION_TIMEOUT: u32 = 300;
+
 #[contractimpl]
 impl StorageInitializationContract {
     // Initialize contract with comprehensive setup
@@ -442,8 +450,8 @@ impl StorageInitializationContract {
                 auto_fix_issues: true,
                 validation_enabled: true,
                 backup_before_fix: true,
-                max_retry_attempts: 3,
-                initialization_timeout: 300,
+                max_retry_attempts: DEFAULT_MAX_RETRY_ATTEMPTS,
+                initialization_timeout: DEFAULT_INITIALIZATION_TIMEOUT,
             },
         }
     }

--- a/contract/subscription_contract/src/lib.rs
+++ b/contract/subscription_contract/src/lib.rs
@@ -16,6 +16,7 @@ mod test;
 
 use soroban_sdk::{contract, contractimpl, Address, Env, Vec};
 use storage_types::*;
+use utils::SECONDS_PER_DAY;
 
 pub use subscription::*;
 pub use utils::*;
@@ -124,7 +125,7 @@ impl SubscriptionContract {
 
         let subscription_id: u64 = env.storage().instance().get(&DataKey::NextSubscriptionId).unwrap();
         let current_time = env.ledger().timestamp();
-        let duration_seconds = (plan.duration_days as u64).checked_mul(86400).expect("Time overflow");
+        let duration_seconds = (plan.duration_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
         let end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
 
         let subscription = UserSubscription {
@@ -178,7 +179,7 @@ impl SubscriptionContract {
         subscription::process_subscription_payment(&env, &user, &plan);
 
         let current_time = env.ledger().timestamp();
-        let duration_seconds = (plan.duration_days as u64).checked_mul(86400).expect("Time overflow");
+        let duration_seconds = (plan.duration_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
         subscription.end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
         subscription.last_payment_date = current_time;
         subscription.status = SubscriptionStatus::Active;
@@ -257,7 +258,7 @@ impl SubscriptionContract {
 
         let current_time = env.ledger().timestamp();
         let remaining_time = subscription.end_date.checked_sub(current_time).expect("Time error");
-        let remaining_days = (remaining_time.checked_div(86400).expect("Time error")) as u32;
+        let remaining_days = (remaining_time.checked_div(SECONDS_PER_DAY).expect("Time error")) as u32;
 
         let paused_data = PausedSubscriptionData {
             paused_at: current_time,
@@ -301,7 +302,7 @@ impl SubscriptionContract {
             .expect("Paused data not found");
 
         let current_time = env.ledger().timestamp();
-        let remaining_seconds = (paused_data.remaining_days as u64).checked_mul(86400).expect("Time overflow");
+        let remaining_seconds = (paused_data.remaining_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
         let new_end_date = current_time.checked_add(remaining_seconds).expect("Time overflow");
 
         subscription.status = SubscriptionStatus::Active;
@@ -529,7 +530,7 @@ impl SubscriptionContract {
 
         let subscription_id: u64 = env.storage().instance().get(&DataKey::NextSubscriptionId).unwrap();
         let current_time = env.ledger().timestamp();
-        let duration_seconds = (plan.duration_days as u64).checked_mul(86400).expect("Time overflow");
+        let duration_seconds = (plan.duration_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
         let end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
 
         let subscription = UserSubscription {
@@ -592,7 +593,7 @@ impl SubscriptionContract {
 
         if subscription.status == SubscriptionStatus::Active && current_time > subscription.end_date {
             let grace_period_days: u32 = env.storage().instance().get(&DataKey::GracePeriod).unwrap();
-            let grace_period_seconds = (grace_period_days as u64).checked_mul(86400).expect("Time overflow");
+            let grace_period_seconds = (grace_period_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
             let grace_period_end = subscription.end_date.checked_add(grace_period_seconds).expect("Time overflow");
 
             if current_time <= grace_period_end {

--- a/contract/subscription_contract/src/subscription.rs
+++ b/contract/subscription_contract/src/subscription.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{token, Address, Env};
 
 use crate::storage_types::*;
+use crate::utils::SECONDS_PER_DAY;
 
 /// Process subscription payment using Soroban token
 pub fn process_subscription_payment(env: &Env, user: &Address, plan: &SubscriptionPlan) {
@@ -78,7 +79,7 @@ pub fn calculate_plan_change_amount(
     let old_plan_remaining_value = (old_plan.price * remaining_duration as i128) / total_duration as i128;
     
     // Calculate prorated value of new plan for remaining time
-    let new_plan_prorated_value = (new_plan.price * remaining_duration as i128) / (new_plan.duration_days as i128 * 86400);
+    let new_plan_prorated_value = (new_plan.price * remaining_duration as i128) / (new_plan.duration_days as i128 * SECONDS_PER_DAY as i128);
 
     // Positive means upgrade (user pays), negative means downgrade (user gets refund)
     new_plan_prorated_value - old_plan_remaining_value
@@ -91,7 +92,7 @@ pub fn is_payment_due(env: &Env, subscription: &UserSubscription) -> bool {
     // Check if subscription is about to expire (within 1 day)
     if subscription.auto_renew && subscription.status == SubscriptionStatus::Active {
         let time_until_expiry = subscription.end_date.saturating_sub(current_time);
-        return time_until_expiry <= 86400; // 1 day in seconds
+        return time_until_expiry <= SECONDS_PER_DAY; // 1 day in seconds
     }
     
     false
@@ -117,5 +118,5 @@ pub fn calculate_remaining_days(env: &Env, subscription: &UserSubscription) -> u
     }
 
     let remaining_seconds = subscription.end_date - current_time;
-    (remaining_seconds / 86400) as u32
+    (remaining_seconds / SECONDS_PER_DAY) as u32
 }

--- a/contract/subscription_contract/src/utils.rs
+++ b/contract/subscription_contract/src/utils.rs
@@ -1,13 +1,16 @@
 use soroban_sdk::Env;
 
+/// Number of seconds in one day.
+pub const SECONDS_PER_DAY: u64 = 86_400;
+
 /// Convert days to seconds
 pub fn days_to_seconds(days: u32) -> u64 {
-    days as u64 * 86400
+    days as u64 * SECONDS_PER_DAY
 }
 
 /// Convert seconds to days
 pub fn seconds_to_days(seconds: u64) -> u32 {
-    (seconds / 86400) as u32
+    (seconds / SECONDS_PER_DAY) as u32
 }
 
 /// Get current timestamp

--- a/contract/ticket_contract/src/lib.rs
+++ b/contract/ticket_contract/src/lib.rs
@@ -45,9 +45,30 @@ mod upgrade_manager;
 mod core;
 
 // Dynamic pricing constants
-const PRICE_INCREASE_BPS: i128 = 500; // 5% increase per tier threshold
-const EARLY_BIRD_DISCOUNT_BPS: i128 = 1000; // 10% discount max
-const ORACLE_PRECISION: i128 = 10000; // Assuming oracle returns multiplier in bps (e.g. 10000 = 1x)
+/// Basis points increase applied per demand tier threshold (500 bps = 5%).
+const PRICE_INCREASE_BPS: i128 = 500;
+/// Maximum early-bird discount in basis points (1000 bps = 10%).
+const EARLY_BIRD_DISCOUNT_BPS: i128 = 1000;
+/// Basis points uplift applied to the AbTestB floor price (2000 bps = 20%).
+const AB_TEST_B_FLOOR_UPLIFT_BPS: i128 = 2000;
+/// Divisor used to convert basis-point values to a price ratio (10000 bps = 100%).
+const BPS_PRECISION: i128 = 10000;
+
+// Time constants
+/// Number of seconds in one week, used to compute the early-bird purchase window.
+const ONE_WEEK_SECONDS: u64 = 604_800;
+/// Number of seconds in one hour, used as the default oracle price update frequency.
+const ONE_HOUR_SECONDS: u64 = 3_600;
+
+// Rate-limiting constants
+/// Default anti-sniping minimum lock period in ledgers.
+const ANTI_SNIPING_MIN_LOCK_PERIOD: u32 = 10;
+/// Default anti-sniping maximum entries per address.
+const ANTI_SNIPING_MAX_ENTRIES: u32 = 5;
+/// Default rate-limit window duration in seconds (1 hour).
+const DEFAULT_RATE_LIMIT_WINDOW: u64 = 3_600;
+/// Default randomization delay for anti-sniping protection, in ledgers.
+const ANTI_SNIPING_RANDOMIZATION_DELAY: u32 = 3;
 
 #[contract]
 pub struct SoulboundTicketContract;
@@ -90,7 +111,7 @@ impl SoulboundTicketContract {
             dex_pool_address: admin.clone(), // Update via set_pricing_config after deployment
             price_floor: 0,
             price_ceiling: i128::MAX,
-            update_frequency: 3600,
+            update_frequency: ONE_HOUR_SECONDS,
             last_update_time: e.ledger().timestamp(),
             is_frozen: false,
             oracle_pair: String::from_str(e, "XLM/USD"),
@@ -252,10 +273,10 @@ impl SoulboundTicketContract {
 
         // Initialize anti-sniping config
         let anti_sniping = AllocAntiSnipingConfig {
-            minimum_lock_period: 10,
-            max_entries_per_address: 5,
-            rate_limit_window: 3600,
-            randomization_delay_ledgers: 3,
+            minimum_lock_period: ANTI_SNIPING_MIN_LOCK_PERIOD,
+            max_entries_per_address: ANTI_SNIPING_MAX_ENTRIES,
+            rate_limit_window: DEFAULT_RATE_LIMIT_WINDOW,
+            randomization_delay_ledgers: ANTI_SNIPING_RANDOMIZATION_DELAY,
         };
 
         e.storage()
@@ -612,10 +633,10 @@ impl SoulboundTicketContract {
     ///  2. Verify that the returned timestamp is within `max_oracle_age_seconds`.
     ///  3. If the oracle is stale or the cross-contract call fails, fall back to
     ///     `DexPriceRouterClient::try_get_spot_price(pair)` on the DEX address.
-    ///  4. If both fail, return `ORACLE_PRECISION` (neutral — no adjustment).
+    ///  4. If both fail, return `BPS_PRECISION` (neutral — no adjustment).
     ///
     /// The raw price (8 decimals, $1.00 == 100_000_000) is converted into a
-    /// `ORACLE_PRECISION`-scaled multiplier using the stored `oracle_reference_price`.
+    /// `BPS_PRECISION`-scaled multiplier using the stored `oracle_reference_price`.
     fn fetch_oracle_multiplier(e: &Env, config: &PricingConfig) -> i128 {
         match fetch_price_with_fallback(
             e,
@@ -627,10 +648,10 @@ impl SoulboundTicketContract {
             Some(result) => oracle_price_to_multiplier(
                 result.price,
                 config.oracle_reference_price,
-                ORACLE_PRECISION,
+                BPS_PRECISION,
             ),
             // Both oracle and DEX unavailable: apply neutral multiplier (no adjustment)
-            None => ORACLE_PRECISION,
+            None => BPS_PRECISION,
         }
     }
 
@@ -653,7 +674,7 @@ impl SoulboundTicketContract {
                 // Demand based: base_price * (1 + (minted / (max_supply / 5)) * 5%)
                 let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
                 let multiplier = (thresholds_passed as i128).checked_mul(PRICE_INCREASE_BPS).expect("Arithmetic overflow");
-                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(10000)).expect("Arithmetic overflow");
+                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
                 price = price.checked_add(increase).expect("Arithmetic overflow");
             }
             PricingStrategy::TimeDecay => {
@@ -662,9 +683,9 @@ impl SoulboundTicketContract {
                 let now = e.ledger().timestamp();
                 // If purchased way before event, apply 10% discount
                 // Assume linear scale from start to event_start_time
-                let start = event_info.start_time.saturating_sub(604800); // 1 week before
+                let start = event_info.start_time.saturating_sub(ONE_WEEK_SECONDS); // 1 week before
                 if now < start {
-                    let discount = price.checked_mul(EARLY_BIRD_DISCOUNT_BPS).and_then(|v| v.checked_div(10000)).expect("Arithmetic overflow");
+                    let discount = price.checked_mul(EARLY_BIRD_DISCOUNT_BPS).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
                     price = price.checked_sub(discount).expect("Arithmetic overflow");
                 }
             }
@@ -672,19 +693,19 @@ impl SoulboundTicketContract {
                 // High demand sensitivity (10% increase per threshold)
                 let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
                 let multiplier = (thresholds_passed as i128).checked_mul(PRICE_INCREASE_BPS * 2).expect("Arithmetic overflow");
-                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(10000)).expect("Arithmetic overflow");
+                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
                 price = price.checked_add(increase).expect("Arithmetic overflow");
             }
             PricingStrategy::AbTestB => {
                 // Floor starts higher (+20%)
-                let uplift = price.checked_mul(2000).and_then(|v| v.checked_div(10000)).expect("Arithmetic overflow");
+                let uplift = price.checked_mul(AB_TEST_B_FLOOR_UPLIFT_BPS).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
                 price = price.checked_add(uplift).expect("Arithmetic overflow");
             }
         }
 
         // Apply external Oracle factors using the real DIA oracle integration
         let oracle_multiplier = Self::fetch_oracle_multiplier(e, &config);
-        price = price.checked_mul(oracle_multiplier).and_then(|v| v.checked_div(ORACLE_PRECISION)).expect("Arithmetic overflow");
+        price = price.checked_mul(oracle_multiplier).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
 
         // Apply bounds
         price = price.max(config.price_floor).min(config.price_ceiling);

--- a/contract/vrf_contract/src/lib.rs
+++ b/contract/vrf_contract/src/lib.rs
@@ -21,6 +21,23 @@ use soroban_sdk::{
 #[contract]
 pub struct VRFContract;
 
+// ─── VRF Contract Constants ────────────────────────────────────────────────────────
+
+/// Initial reputation score assigned to every new entropy provider (100 = perfect).
+const INITIAL_PROVIDER_REPUTATION: u32 = 100;
+/// Initial selection weight assigned to every new entropy provider.
+const INITIAL_PROVIDER_WEIGHT: u32 = 100;
+/// Maximum possible reputation score for an entropy provider.
+const MAX_PROVIDER_REPUTATION: u32 = 100;
+
+// Entropy source weights — relative importance when mixing entropy sources.
+/// Weight given to the block-hash entropy source.
+const ENTROPY_WEIGHT_BLOCK_HASH: u32 = 30;
+/// Weight given to the ledger-timestamp entropy source.
+const ENTROPY_WEIGHT_TIMESTAMP: u32 = 20;
+/// Weight given to the ledger-sequence entropy source.
+const ENTROPY_WEIGHT_LEDGER_SEQUENCE: u32 = 25;
+
 #[contractimpl]
 impl VRFContract {
     // Initialize the contract
@@ -63,12 +80,12 @@ impl VRFContract {
             address: provider_address.clone(),
             provider_type,
             public_key,
-            reputation_score: 100, // Start with perfect reputation
+            reputation_score: INITIAL_PROVIDER_REPUTATION, // Start with perfect reputation
             success_count: 0,
             failure_count: 0,
             last_used: 0,
             active: true,
-            weight: 100,
+            weight: INITIAL_PROVIDER_WEIGHT,
             fee,
         };
 
@@ -250,7 +267,7 @@ impl VRFContract {
 
         if success {
             provider_info.success_count += 1;
-            provider_info.reputation_score = (provider_info.reputation_score + 1).min(100);
+            provider_info.reputation_score = (provider_info.reputation_score + 1).min(MAX_PROVIDER_REPUTATION);
         } else {
             provider_info.failure_count += 1;
             provider_info.reputation_score = provider_info.reputation_score.saturating_sub(10);
@@ -330,7 +347,7 @@ impl VRFContract {
         sources.push_back(EntropySource {
             source_type: SourceType::BlockHash,
             value: block_hash,
-            weight: 30,
+            weight: ENTROPY_WEIGHT_BLOCK_HASH,
             timestamp: e.ledger().timestamp(),
             reliability: 0.9,
         });
@@ -341,7 +358,7 @@ impl VRFContract {
         sources.push_back(EntropySource {
             source_type: SourceType::Timestamp,
             value: timestamp_hash,
-            weight: 20,
+            weight: ENTROPY_WEIGHT_TIMESTAMP,
             timestamp: e.ledger().timestamp(),
             reliability: 0.8,
         });
@@ -352,7 +369,7 @@ impl VRFContract {
         sources.push_back(EntropySource {
             source_type: SourceType::LedgerSequence,
             value: sequence_hash,
-            weight: 25,
+            weight: ENTROPY_WEIGHT_LEDGER_SEQUENCE,
             timestamp: e.ledger().timestamp(),
             reliability: 0.9,
         });
@@ -362,7 +379,7 @@ impl VRFContract {
         sources.push_back(EntropySource {
             source_type: SourceType::NetworkEntropy,
             value: network_entropy,
-            weight: 25,
+            weight: ENTROPY_WEIGHT_LEDGER_SEQUENCE, // same weight as ledger sequence
             timestamp: e.ledger().timestamp(),
             reliability: 0.7,
         });

--- a/contract/zk_ticket_contract/src/lib.rs
+++ b/contract/zk_ticket_contract/src/lib.rs
@@ -21,6 +21,20 @@ use soroban_sdk::{
 #[contract]
 pub struct ZKTicketContract;
 
+// ─── ZK Ticket Constants ────────────────────────────────────────────────────────────
+
+/// Minimum required byte length for a full ZK proof payload.
+/// Proofs shorter than this are rejected as malformed.
+const MIN_ZK_PROOF_DATA_LEN: u32 = 100;
+/// Minimum required byte length for a mobile-optimized ZK proof payload.
+/// Mobile proofs use a lighter format, so the threshold is lower.
+const MIN_MOBILE_PROOF_DATA_LEN: u32 = 50;
+/// TTL (in ledgers) for temporary mobile-proof storage.
+/// Corresponds to approximately 5 minutes at 1-second ledger close times.
+const MOBILE_PROOF_TTL_LEDGERS: u32 = 300;
+/// Cache validity window in seconds for verification results (5 minutes).
+const VERIFICATION_CACHE_TTL_SECONDS: u64 = 300;
+
 /// The ZK Ticket Contract enables privacy-preserving ticket verification using Zero-Knowledge Proofs.
 ///
 /// This contract allows event organizers to issue ticket commitments that users can later
@@ -308,7 +322,7 @@ impl ZKTicketContract {
         mobile_data.last_used = env.ledger().timestamp();
         mobile_data.usage_count = mobile_data.usage_count.checked_add(1).expect("Usage count overflow");
 
-        env.storage().temporary().set(&mobile_device_id, &mobile_data, 300);
+        env.storage().temporary().set(&mobile_device_id, &mobile_data, MOBILE_PROOF_TTL_LEDGERS);
 
         Ok(verification_result)
     }
@@ -532,7 +546,7 @@ impl ZKTicketContract {
         let circuit_params: CircuitParameters = e.storage().instance().get(&DataKey::CircuitParams).unwrap();
         
         // Verify proof format and structure
-        if proof_data.len() < 100 {
+        if proof_data.len() < MIN_ZK_PROOF_DATA_LEN {
             return Err(ZKTicketError::InvalidProof);
         }
 
@@ -586,7 +600,7 @@ impl ZKTicketContract {
         if let Some(cached) = env.storage().instance().get(&DataKey::VerificationCache) {
             let cache_typed: VerificationCache = cached;
             let elapsed = env.ledger().timestamp().checked_sub(cache_typed.timestamp).expect("Time error");
-            if cache_typed.cache_key == cache_key && elapsed < 300 { // 5 minute cache
+            if cache_typed.cache_key == cache_key && elapsed < VERIFICATION_CACHE_TTL_SECONDS { // 5 minute cache
                 return cache_typed.result;
             }
         }
@@ -607,7 +621,7 @@ impl ZKTicketContract {
 
     fn verify_mobile_proof_internal(e: &Env, proof_template: &Vec<u8>, proof_data: &Vec<u8>) -> Result<bool, ZKTicketError> {
         // Simplified mobile verification - optimized for mobile devices
-        if proof_data.len() < 50 {
+        if proof_data.len() < MIN_MOBILE_PROOF_DATA_LEN {
             return Err(ZKTicketError::MobileVerificationFailed);
         }
 


### PR DESCRIPTION
…ants

- governance_contract: extract CATEGORY_*, *_QUORUM, *_APPROVAL_THRESHOLD, *_PERIOD, and MIN_PROPOSE_POWER constants; replace all inline literals in init() and create_proposal()
- ticket_contract: rename ORACLE_PRECISION to BPS_PRECISION; add AB_TEST_B_FLOOR_UPLIFT_BPS (2000), ONE_WEEK_SECONDS (604800), ONE_HOUR_SECONDS (3600), and anti-sniping defaults (ANTI_SNIPING_MIN_LOCK_PERIOD, ANTI_SNIPING_MAX_ENTRIES, DEFAULT_RATE_LIMIT_WINDOW, ANTI_SNIPING_RANDOMIZATION_DELAY); replace all inline BPS/time literals
- dutch_auction_contract: add DECAY_PRECISION (1_000_000) and DECAY_SCALE_DIVISOR (100); replace all inline literals in calculate_price()
- vrf_contract: add INITIAL_PROVIDER_REPUTATION (100), INITIAL_PROVIDER_WEIGHT (100), MAX_PROVIDER_REPUTATION (100), ENTROPY_WEIGHT_BLOCK_HASH (30), ENTROPY_WEIGHT_TIMESTAMP (20), ENTROPY_WEIGHT_LEDGER_SEQUENCE (25); replace all inline literals in register_provider() and collect_entropy_sources()
- zk_ticket_contract: add MIN_ZK_PROOF_DATA_LEN (100), MIN_MOBILE_PROOF_DATA_LEN (50), MOBILE_PROOF_TTL_LEDGERS (300), VERIFICATION_CACHE_TTL_SECONDS (300); replace all inline literals
- feature_flag_contract: add ANALYTICS_TTL_LEDGERS (3_600), SECONDS_PER_DAY (86_400), MAX_ROLLOUT_PERCENTAGE (100), ROLLOUT_HASH_MODULUS (100); replace all inline literals in rollout evaluators, analytics TTL, and validators
- storage_initialization_contract: add DEFAULT_MAX_RETRY_ATTEMPTS (3) and DEFAULT_INITIALIZATION_TIMEOUT (300); replace inline literals in default config
- subscription_contract: add pub SECONDS_PER_DAY (86_400) constant to utils.rs; import and use it throughout lib.rs, subscription.rs, and utils.rs; replace all 86400 occurrences with the named constant

All constants are documented with inline doc comments explaining units and semantics.


Closes #292 