### PR TITLE
refactor(contracts): replace generic primitives with named type aliases

### DIFF
--- a/contract/common/src/lib.rs
+++ b/contract/common/src/lib.rs
@@ -10,6 +10,7 @@ pub mod access;
 pub mod error;
 pub mod reentrancy;
 pub mod storage;
+pub mod types;
 pub mod upgrade;
 pub mod validation;
 
@@ -17,5 +18,6 @@ pub use access::*;
 pub use error::*;
 pub use reentrancy::*;
 pub use storage::*;
+pub use types::*;
 pub use upgrade::*;
 pub use validation::*;

--- a/contract/common/src/types.rs
+++ b/contract/common/src/types.rs
@@ -1,0 +1,83 @@
+/// Shared primitive type aliases and newtypes for all Gatherraa contracts.
+///
+/// Using named aliases instead of raw primitives makes function signatures and
+/// struct fields self-documenting, prevents accidental parameter swaps, and
+/// centralises the mapping between domain concepts and underlying storage types.
+
+// ─── Primitive domain aliases ────────────────────────────────────────────────
+
+/// A Unix timestamp expressed in seconds (maps to `u64`).
+///
+/// Use this wherever a field or parameter represents a point in time.
+pub type Timestamp = u64;
+
+/// A ledger sequence number (maps to `u32`).
+///
+/// Used for on-chain timing (voting periods, timelocks, etc.).
+pub type LedgerSequence = u32;
+
+/// A token amount expressed in the token's smallest indivisible unit (maps to `i128`).
+///
+/// All balances, prices, fees, and reward amounts should use this alias.
+pub type TokenAmount = i128;
+
+/// A value expressed in basis points, where 10_000 bps == 100% (maps to `u32`).
+///
+/// Use for fee rates, discount rates, reward multipliers and similar ratios.
+pub type BasisPoints = u32;
+
+/// A percentage value in the range [0, 100] (maps to `u32`).
+///
+/// Distinct from `BasisPoints` to make the intended scale unambiguous.
+pub type Percentage = u32;
+
+// ─── Domain ID aliases ───────────────────────────────────────────────────────
+
+/// Unique numeric identifier for a governance proposal (maps to `u32`).
+pub type ProposalId = u32;
+
+/// Unique numeric identifier for a subscription plan (maps to `u32`).
+pub type PlanId = u32;
+
+/// Unique numeric identifier for a subscription instance (maps to `u64`).
+pub type SubscriptionId = u64;
+
+/// Unique numeric identifier for a gift subscription (maps to `u64`).
+pub type GiftId = u64;
+
+/// Unique numeric identifier for a claim attached to a DID (maps to `u32`).
+pub type ClaimId = u32;
+
+/// Unique numeric identifier for a milestone within an escrow (maps to `u32`).
+pub type MilestoneId = u32;
+
+/// Unique numeric identifier for a staking reward tier (maps to `u32`).
+pub type TierId = u32;
+
+/// Unique numeric identifier for a governance category (maps to `u32`).
+pub type CategoryId = u32;
+
+/// Unique numeric identifier for a signer weight / M-of-N threshold (maps to `u32`).
+pub type SignerWeight = u32;
+
+// ─── Duration aliases ────────────────────────────────────────────────────────
+
+/// A duration expressed in seconds (maps to `u64`).
+///
+/// Prefer this over `Timestamp` when a value represents a *length of time*
+/// rather than a *point in time*.
+pub type DurationSeconds = u64;
+
+/// A duration expressed in days (maps to `u32`).
+pub type DurationDays = u32;
+
+/// A duration expressed in ledger sequences (maps to `u32`).
+pub type DurationLedgers = u32;
+
+// ─── Score / quality aliases ─────────────────────────────────────────────────
+
+/// A reputation or quality score in the range [0, 100] (maps to `u32`).
+pub type ReputationScore = u32;
+
+/// A selection weight used when randomly sampling entropy providers (maps to `u32`).
+pub type ProviderWeight = u32;

--- a/contract/contracts/src/types.rs
+++ b/contract/contracts/src/types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, Address, Symbol};
+use gathera_common::types::{Timestamp, TokenAmount, DurationSeconds, TierId};
 
 /// Storage keys for the Staking Contract.
 #[contracttype]
@@ -8,7 +9,7 @@ pub enum DataKey {
     Config,
     /// Reward tier information: [u32] (Tier ID).
     Tier(u32),
-    /// Information about a specific staker: [Address].
+    /// Storage key for a specific staker: [Address].
     UserInfo(Address),
     /// Accumulated reward per token stored.
     RewardPerTokenStored,
@@ -35,7 +36,7 @@ pub struct Config {
     /// Token used for rewards.
     pub reward_token: Address,
     /// Global reward rate per second.
-    pub reward_rate: i128,
+    pub reward_rate: TokenAmount,
 }
 
 /// A specific reward tier for staking.
@@ -43,7 +44,7 @@ pub struct Config {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Tier {
     /// Minimum amount of tokens required for this tier.
-    pub min_amount: i128,
+    pub min_amount: TokenAmount,
     /// Reward multiplier (e.g., 100 = 1x, 150 = 1.5x).
     pub reward_multiplier: u32,
 }
@@ -53,17 +54,17 @@ pub struct Tier {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UserInfo {
     /// Current amount of tokens staked.
-    pub amount: i128,
+    pub amount: TokenAmount,
     /// Equivalent shares based on reward tiers.
-    pub shares: i128,
+    pub shares: TokenAmount,
     /// Last reward per token amount that was paid out or updated.
-    pub reward_per_token_paid: i128,
+    pub reward_per_token_paid: TokenAmount,
     /// Accumulated rewards waiting to be claimed.
-    pub rewards: i128,
+    pub rewards: TokenAmount,
     /// Timestamp when the current stake was locked.
-    pub lock_start_time: u64,
+    pub lock_start_time: Timestamp,
     /// Total duration for which the stake is locked.
-    pub lock_duration: u64,
+    pub lock_duration: DurationSeconds,
     /// Current assigned tier ID for the user.
-    pub tier_id: u32,
+    pub tier_id: TierId,
 }

--- a/contract/dutch_auction_contract/src/storage_types.rs
+++ b/contract/dutch_auction_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map, U256};
+use gathera_common::types::{Timestamp, TokenAmount, DurationSeconds};
 
 #[derive(Clone)]
 pub enum DataKey {
@@ -20,34 +21,34 @@ pub struct Auction {
     pub organizer: Address,
     pub token: Address,
     pub ticket_nft: Address,
-    pub initial_price: i128,
-    pub reserve_price: i128,
-    pub floor_price: i128,
+    pub initial_price: TokenAmount,
+    pub reserve_price: TokenAmount,
+    pub floor_price: TokenAmount,
     pub decay_constant: u32, // k in the exponential decay formula
-    pub start_time: u64,
-    pub duration: u64,
-    pub extension_threshold: u64, // Time before end that triggers extension
-    pub extension_duration: u64,   // How much to extend by
-    pub current_price: i128,
+    pub start_time: Timestamp,
+    pub duration: DurationSeconds,
+    pub extension_threshold: DurationSeconds, // Time before end that triggers extension
+    pub extension_duration: DurationSeconds,   // How much to extend by
+    pub current_price: TokenAmount,
     pub total_tickets: u32,
     pub sold_tickets: u32,
     pub status: AuctionStatus,
     pub bids: Vec<Bid>,
     pub winner_commitments: Map<Address, BytesN<32>>, // For commit-reveal
-    pub final_extension_time: u64,
+    pub final_extension_time: Timestamp,
     pub anti_bot_enabled: bool,
-    pub min_bid_increment: i128,
+    pub min_bid_increment: TokenAmount,
 }
 
 #[derive(Clone)]
 pub struct Bid {
     pub bidder: Address,
-    pub amount: i128,
-    pub timestamp: u64,
+    pub amount: TokenAmount,
+    pub timestamp: Timestamp,
     pub commitment: Option<BytesN<32>>, // For commit-reveal scheme
     pub revealed: bool,
     pub ticket_ids: Vec<u32>,
-    pub refund_amount: i128,
+    pub refund_amount: TokenAmount,
 }
 
 #[derive(Clone, PartialEq)]
@@ -61,33 +62,33 @@ pub enum AuctionStatus {
 #[derive(Clone)]
 pub struct AuctionConfig {
     pub max_concurrent_auctions: u32,
-    pub default_duration: u64,
-    pub default_extension_threshold: u64,
-    pub default_extension_duration: u64,
+    pub default_duration: DurationSeconds,
+    pub default_extension_threshold: DurationSeconds,
+    pub default_extension_duration: DurationSeconds,
     pub default_decay_constant: u32,
-    pub max_duration: u64,
-    pub min_duration: u64,
+    pub max_duration: DurationSeconds,
+    pub min_duration: DurationSeconds,
     pub anti_bot_enabled: bool,
-    pub rate_limit_window: u64,
+    pub rate_limit_window: DurationSeconds,
     pub rate_limit_max_bids: u32,
     pub commit_reveal_enabled: bool,
-    pub commit_reveal_timeout: u64,
+    pub commit_reveal_timeout: DurationSeconds,
 }
 
 #[derive(Clone)]
 pub struct RateLimiter {
     pub address: Address,
     pub bid_count: u32,
-    pub window_start: u64,
-    pub last_bid_time: u64,
+    pub window_start: Timestamp,
+    pub last_bid_time: Timestamp,
 }
 
 #[derive(Clone)]
 pub struct CommitReveal {
     pub commitment: BytesN<32>,
     pub reveal_hash: Option<BytesN<32>>,
-    pub reveal_time: Option<u64>,
-    pub amount: Option<i128>,
+    pub reveal_time: Option<Timestamp>,
+    pub amount: Option<TokenAmount>,
     pub revealed: bool,
 }
 

--- a/contract/escrow_contract/src/storage_types.rs
+++ b/contract/escrow_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, Address, BytesN, Env, Symbol, Vec, Map, U256, String, i128, u64, u32};
+use gathera_common::types::{Timestamp, TokenAmount, Percentage, MilestoneId, DurationSeconds};
 
 /// Storage keys for the Escrow Contract.
 #[contracttype]
@@ -44,13 +45,13 @@ pub struct Escrow {
     /// Address of the student/purchaser.
     pub purchaser: Address,
     /// Total amount of tokens locked.
-    pub amount: i128,
+    pub amount: TokenAmount,
     /// Token address used for the escrow.
     pub token: Address,
     /// Timestamp when the escrow was created.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Timestamp when the tokens are scheduled for release.
-    pub release_time: u64,
+    pub release_time: Timestamp,
     /// Current status of the escrow.
     pub status: EscrowStatus,
     /// Revenue split configuration for this escrow.
@@ -84,11 +85,11 @@ pub enum EscrowStatus {
 #[derive(Clone)]
 pub struct RevenueSplit {
     /// Percentage allocated to the organizer.
-    pub organizer_percentage: u32,
+    pub organizer_percentage: Percentage,
     /// Percentage allocated to the platform.
-    pub platform_percentage: u32,
+    pub platform_percentage: Percentage,
     /// Percentage allocated to the referrer (if any).
-    pub referral_percentage: u32,
+    pub referral_percentage: Percentage,
     /// Calculation precision (e.g., 10000 for 100.00%).
     pub precision: u32,
 }
@@ -97,11 +98,11 @@ pub struct RevenueSplit {
 #[derive(Clone)]
 pub struct Milestone {
     /// Unique identifier for the milestone within the escrow.
-    pub id: u32,
+    pub id: MilestoneId,
     /// Amount of tokens to release upon completion.
-    pub amount: i128,
+    pub amount: TokenAmount,
     /// Minimum time before this milestone can be released.
-    pub release_time: u64,
+    pub release_time: Timestamp,
     /// Whether the milestone has already been released.
     pub released: bool,
 }
@@ -118,7 +119,7 @@ pub struct Dispute {
     /// List of symbols linking to evidence (e.g., hash of documents).
     pub evidence: Vec<Symbol>,
     /// Timestamp when the dispute was created.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Whether the dispute has been resolved.
     pub resolved: bool,
     /// Outcome of the dispute resolution.
@@ -147,9 +148,9 @@ pub struct DisputeResolution {
     /// Address awarded the funds.
     pub winner: Address,
     /// Amount returned to the purchaser.
-    pub refund_amount: i128,
+    pub refund_amount: TokenAmount,
     /// Amount deducted as a penalty or platform fee.
-    pub penalty_amount: i128,
+    pub penalty_amount: TokenAmount,
 }
 
 /// Tracks referral activity and rewards for a user.
@@ -158,34 +159,34 @@ pub struct ReferralTracker {
     /// The user being tracked.
     pub referrer: Address,
     /// Total rewards earned across all referrals.
-    pub total_rewards: i128,
+    pub total_rewards: TokenAmount,
     /// Number of successful referrals.
     pub referral_count: u32,
     /// Timestamp of the last referral event.
-    pub last_referral: u64,
+    pub last_referral: Timestamp,
 }
 
 /// Global parameters for revenue splitting and timeouts.
 #[derive(Clone)]
 pub struct RevenueSplitConfig {
     /// Default organizer share.
-    pub default_organizer_percentage: u32,
+    pub default_organizer_percentage: Percentage,
     /// Default platform fee.
-    pub default_platform_percentage: u32,
+    pub default_platform_percentage: Percentage,
     /// Default referral reward.
-    pub default_referral_percentage: u32,
+    pub default_referral_percentage: Percentage,
     /// Absolute maximum allowed referral reward.
-    pub max_referral_percentage: u32,
+    pub max_referral_percentage: Percentage,
     /// Precision used for percentage math.
     pub precision: u32,
     /// Minimum allowed escrow amount.
-    pub min_escrow_amount: i128,
+    pub min_escrow_amount: TokenAmount,
     /// Maximum allowed escrow amount.
-    pub max_escrow_amount: i128,
+    pub max_escrow_amount: TokenAmount,
     /// Seconds to wait before a dispute can be auto-resolved or escalated.
-    pub dispute_timeout: u64,
+    pub dispute_timeout: DurationSeconds,
     /// Time delay for administrative emergency withdrawals.
-    pub emergency_withdrawal_delay: u64,
+    pub emergency_withdrawal_delay: DurationSeconds,
 }
 
 // Custom errors

--- a/contract/feature_flag_contract/Cargo.toml
+++ b/contract/feature_flag_contract/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "23.5.2"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/feature_flag_contract/src/storage_types.rs
+++ b/contract/feature_flag_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map, U256};
+use gathera_common::types::Timestamp;
 
 #[derive(Clone)]
 pub enum DataKey {
@@ -23,8 +24,8 @@ pub struct FeatureFlag {
     pub environment: Environment,
     pub segments: Vec<Symbol>,
     pub rules: Vec<SegmentRule>,
-    pub created_at: u64,
-    pub updated_at: u64,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
     pub created_by: Address,
     pub description: String,
     pub tags: Vec<Symbol>,
@@ -76,7 +77,7 @@ pub struct UserSegment {
     pub user: Address,
     pub segments: Vec<Symbol>,
     pub attributes: Map<Symbol, soroban_sdk::Val>,
-    pub last_updated: u64,
+    pub last_updated: Timestamp,
     pub version: u32,
 }
 
@@ -87,8 +88,8 @@ pub struct ABTest {
     pub feature_flag: Symbol,
     pub variants: Vec<TestVariant>,
     pub traffic_allocation: Map<Symbol, u32>,
-    pub start_time: u64,
-    pub end_time: u64,
+    pub start_time: Timestamp,
+    pub end_time: Timestamp,
     pub status: ABTestStatus,
     pub sample_size: u32,
     pub confidence_threshold: u32,
@@ -117,13 +118,13 @@ pub struct RolloutPlan {
     pub stages: Vec<RolloutStage>,
     pub current_stage: u32,
     pub auto_advance: bool,
-    pub created_at: u64,
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone)]
 pub struct RolloutStage {
     pub percentage: u32,
-    pub duration: u64,
+    pub duration: Timestamp,
     pub criteria: Vec<Condition>,
     pub completed: bool,
 }
@@ -143,7 +144,7 @@ pub struct AnalyticsData {
     pub user: Address,
     pub evaluation: bool,
     pub variant: Option<Symbol>,
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
     pub context: Map<Symbol, soroban_sdk::Val>,
     pub environment: Environment,
 }
@@ -161,10 +162,10 @@ pub struct KillSwitch {
     pub flag_key: Symbol,
     pub active: bool,
     pub triggered_by: Address,
-    pub triggered_at: u64,
+    pub triggered_at: Timestamp,
     pub reason: String,
     pub auto_recovery: bool,
-    pub recovery_time: Option<u64>,
+    pub recovery_time: Option<Timestamp>,
 }
 
 // Custom errors

--- a/contract/governance_contract/Cargo.toml
+++ b/contract/governance_contract/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "23.5.2"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/governance_contract/src/storage.rs
+++ b/contract/governance_contract/src/storage.rs
@@ -1,4 +1,8 @@
 use soroban_sdk::{contracttype, Address, Vec, String};
+use gathera_common::types::{
+    Timestamp, LedgerSequence, TokenAmount, BasisPoints, Percentage,
+    ProposalId, CategoryId,
+};
 
 #[derive(Clone)]
 #[contracttype]
@@ -7,20 +11,23 @@ pub enum DataKey {
     Token,
     TimelockDuration,
     EmergencyAddress,
-    Proposal(u32),
+    Proposal(ProposalId),
     ProposalCount,
-    Vote(u32, Address), // (ProposalID, Voter)
+    Vote(ProposalId, Address), // (ProposalID, Voter)
     UserDelegation(Address), // User -> Delegatee
-    UserVotesRevoked(u32, Address),
-    CategorySettings(u32), // CategoryID -> CategorySettings
+    UserVotesRevoked(ProposalId, Address),
+    CategorySettings(CategoryId), // CategoryID -> CategorySettings
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub struct CategorySettings {
-    pub quorum: i128,      // Minimum votes required for proposal to be valid
-    pub threshold: u32,   // Percentage of 'for' votes needed (e.g. 51, 66)
-    pub voting_period: u32, // Number of blocks/ledgers
+    /// Minimum token votes required for the proposal to be valid.
+    pub quorum: TokenAmount,
+    /// Percentage of 'for' votes needed to pass (e.g. 51, 66).
+    pub threshold: Percentage,
+    /// Voting duration in ledger sequences.
+    pub voting_period: LedgerSequence,
 }
 
 
@@ -28,7 +35,7 @@ pub struct CategorySettings {
 #[contracttype]
 pub enum GovernanceAction {
     Upgrade(String), // New WASM hash
-    FeeChange(u32),  // New fee in basis points
+    FeeChange(BasisPoints),  // New fee in basis points
     ParameterChange(String, u32), // Param name, new value
     EmergencyAction,
 }
@@ -58,17 +65,18 @@ pub enum ProposalStatus {
 #[derive(Clone)]
 #[contracttype]
 pub struct Proposal {
-    pub id: u32,
+    pub id: ProposalId,
     pub proposer: Address,
     pub action: GovernanceAction,
     pub category: ProposalCategory,
     pub description: String,
-    pub start_ledger: u32,
-    pub end_ledger: u32,
-    pub total_votes_for: i128,
-    pub total_votes_against: i128,
+    pub start_ledger: LedgerSequence,
+    pub end_ledger: LedgerSequence,
+    pub total_votes_for: TokenAmount,
+    pub total_votes_against: TokenAmount,
     pub status: ProposalStatus,
-    pub eta: u64, // Estimated time for execution after queuing
+    /// Estimated execution time (Unix seconds) after the proposal is queued.
+    pub eta: Timestamp,
 }
 
 #[derive(Clone)]
@@ -76,7 +84,7 @@ pub struct Proposal {
 pub struct VoteRecord {
     pub voter: Address,
     pub support: bool,
-    pub amount: i128,
+    pub amount: TokenAmount,
     pub is_quadratic: bool,
 }
 #[soroban_sdk::contracterror]

--- a/contract/identity_contract/Cargo.toml
+++ b/contract/identity_contract/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "23.5.2"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/identity_contract/src/storage_types.rs
+++ b/contract/identity_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{contracttype, Address, Bytes, String, Vec, BytesN, Symbol};
+use gathera_common::types::{Timestamp, ReputationScore, ClaimId};
 
 #[derive(Clone)]
 #[contracttype]
@@ -21,21 +22,21 @@ pub struct DIDDocument {
     pub id: String,                           // DID identifier
     pub controller: Address,                  // Stellar address controlling this DID
     pub public_key: BytesN<32>,              // Public key for cryptographic operations
-    pub created: u64,                         // Timestamp when created
-    pub updated: u64,                         // Timestamp when last updated
+    pub created: Timestamp,                         // Timestamp when created
+    pub updated: Timestamp,                         // Timestamp when last updated
     pub deactivated: bool,                    // Whether DID is deactivated
     pub claims: Vec<Claim>,                   // List of claims
-    pub reputation_score: u32,                // Reputation score
+    pub reputation_score: ReputationScore,                // Reputation score
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub struct Claim {
-    pub id: u32,                              // Unique claim identifier
+    pub id: ClaimId,                              // Unique claim identifier
     pub claim_type: String,                   // Type of claim (Twitter, GitHub, email, etc.)
     pub claim_value: String,                  // Claim value (handle, email address, etc.)
     pub issuer: Address,                      // Who issued this claim
-    pub issued_at: u64,                       // When claim was issued
+    pub issued_at: Timestamp,                       // When claim was issued
     pub verified: bool,                       // Whether claim is verified by oracle
     pub proof: Bytes,                         // Cryptographic proof of claim
     pub revoked: bool,                        // Whether claim is revoked
@@ -48,8 +49,8 @@ pub struct Credential {
     pub did: String,                          // DID this credential belongs to
     pub credential_type: String,              // Type of credential
     pub issuer: String,                       // Issuer DID
-    pub issued_at: u64,                       // Issuance timestamp
-    pub expires_at: u64,                      // Expiration timestamp
+    pub issued_at: Timestamp,                       // Issuance timestamp
+    pub expires_at: Timestamp,                      // Expiration timestamp
     pub credential_data: Bytes,               // Encrypted credential data
     pub verified: bool,                       // Verification status
     pub revoked: bool,                        // Revocation status
@@ -60,16 +61,16 @@ pub struct Credential {
 pub struct Delegation {
     pub delegate: Address,                    // Address being delegated to
     pub permissions: Vec<String>,             // List of permissions granted
-    pub created_at: u64,                      // When delegation was created
-    pub expiry: u64,                          // When delegation expires
+    pub created_at: Timestamp,                      // When delegation was created
+    pub expiry: Timestamp,                          // When delegation expires
     pub revoked: bool,                        // Whether delegation is revoked
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub struct Revocation {
-    pub claim_id: u32,                        // ID of revoked claim
-    pub revoked_at: u64,                      // When claim was revoked
+    pub claim_id: ClaimId,                        // ID of revoked claim
+    pub revoked_at: Timestamp,                      // When claim was revoked
     pub revoked_by: Address,                  // Who revoked the claim
     pub reason: String,                       // Reason for revocation
 }

--- a/contract/multisig_wallet_contract/src/storage_types.rs
+++ b/contract/multisig_wallet_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map, U256};
+use gathera_common::types::{Timestamp, TokenAmount, DurationSeconds, SignerWeight};
 
 /// Storage keys for the Multisig Wallet Contract.
 #[derive(Clone)]
@@ -35,17 +36,17 @@ pub struct WalletConfig {
     /// Total number of signers (N in M-of-N).
     pub n: u32,
     /// Maximum amount allowed to be spent per day without extra approval.
-    pub daily_spending_limit: i128,
+    pub daily_spending_limit: TokenAmount,
     /// Transactions above this threshold require a timelock.
-    pub timelock_threshold: i128,
+    pub timelock_threshold: TokenAmount,
     /// Mandatory waiting period for high-value transactions (seconds).
-    pub timelock_duration: u64,
+    pub timelock_duration: DurationSeconds,
     /// Duration after which a proposed transaction expires (seconds).
-    pub transaction_expiry: u64,
+    pub transaction_expiry: DurationSeconds,
     /// Maximum number of transactions allowed in a single batch.
     pub max_batch_size: u32,
     /// Duration of a manual emergency freeze (seconds).
-    pub emergency_freeze_duration: u64,
+    pub emergency_freeze_duration: DurationSeconds,
 }
 
 /// A registered signer in the multisig wallet.
@@ -56,15 +57,15 @@ pub struct Signer {
     /// The role assigned to the signer (controls permissions).
     pub role: Role,
     /// The voting weight of the signer.
-    pub weight: u32,
+    pub weight: SignerWeight,
     /// Total amount spent by this signer today.
-    pub daily_spent: i128,
+    pub daily_spent: TokenAmount,
     /// Timestamp when daily spent was last reset.
-    pub last_spending_reset: u64,
+    pub last_spending_reset: Timestamp,
     /// Whether the signer is currently active.
     pub active: bool,
     /// Timestamp when the signer was added to the wallet.
-    pub added_at: u64,
+    pub added_at: Timestamp,
 }
 
 /// Roles that can be assigned to signers.
@@ -88,7 +89,7 @@ pub struct Transaction {
     /// Token address for the transfer.
     pub token: Address,
     /// Amount to transfer.
-    pub amount: i128,
+    pub amount: TokenAmount,
     /// Optional data for contract calls.
     pub data: Vec<u8>,
     /// Address that proposed the transaction.
@@ -98,11 +99,11 @@ pub struct Transaction {
     /// Current lifecycle status.
     pub status: TransactionStatus,
     /// Creation timestamp.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Expiration timestamp.
-    pub expires_at: u64,
+    pub expires_at: Timestamp,
     /// Timestamp after which the transaction can be executed (if timelocked).
-    pub timelock_until: u64,
+    pub timelock_until: Timestamp,
     /// ID of the batch this transaction belongs to, if any.
     pub batch_id: Option<BytesN<32>>,
 }
@@ -138,9 +139,9 @@ pub struct Batch {
     /// Current batch lifecycle status.
     pub status: BatchStatus,
     /// Creation timestamp.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Expiration timestamp.
-    pub expires_at: u64,
+    pub expires_at: Timestamp,
 }
 
 /// Lifecycle status of a batch.
@@ -175,11 +176,11 @@ pub struct TimelockQueue {
 #[derive(Clone)]
 pub struct DailySpending {
     /// The date (start of day).
-    pub date: u64,
+    pub date: Timestamp,
     /// Amount already spent today.
-    pub spent: i128,
+    pub spent: TokenAmount,
     /// Maximum limit for today.
-    pub limit: i128,
+    pub limit: TokenAmount,
 }
 
 /// Managed nonces for replay protection across signatures.

--- a/contract/subscription_contract/Cargo.toml
+++ b/contract/subscription_contract/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "23.5.2"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/subscription_contract/src/storage_types.rs
+++ b/contract/subscription_contract/src/storage_types.rs
@@ -1,18 +1,21 @@
 use soroban_sdk::{contracttype, Address, String, Vec};
+use gathera_common::types::{
+    Timestamp, TokenAmount, Percentage, PlanId, SubscriptionId, GiftId, DurationDays,
+};
 
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
     Admin,
     TokenAddress,
-    SubscriptionPlan(u32),
+    SubscriptionPlan(PlanId),
     UserSubscription(Address),
     FamilyPlan(Address),
     GracePeriod,
     NextPlanId,
     NextSubscriptionId,
     PausedSubscription(Address),
-    GiftedSubscription(u64),
+    GiftedSubscription(GiftId),
 }
 
 #[derive(Clone, Copy, PartialEq)]
@@ -35,10 +38,11 @@ pub enum SubscriptionStatus {
 #[derive(Clone)]
 #[contracttype]
 pub struct SubscriptionPlan {
-    pub plan_id: u32,
+    pub plan_id: PlanId,
     pub tier: SubscriptionTier,
-    pub price: i128,
-    pub duration_days: u32,
+    /// Price in the smallest token unit.
+    pub price: TokenAmount,
+    pub duration_days: DurationDays,
     pub category_ids: Vec<u32>,
     pub max_family_members: u32,
     pub is_active: bool,
@@ -47,13 +51,13 @@ pub struct SubscriptionPlan {
 #[derive(Clone)]
 #[contracttype]
 pub struct UserSubscription {
-    pub subscription_id: u64,
+    pub subscription_id: SubscriptionId,
     pub user: Address,
-    pub plan_id: u32,
+    pub plan_id: PlanId,
     pub status: SubscriptionStatus,
-    pub start_date: u64,
-    pub end_date: u64,
-    pub last_payment_date: u64,
+    pub start_date: Timestamp,
+    pub end_date: Timestamp,
+    pub last_payment_date: Timestamp,
     pub auto_renew: bool,
     pub is_family_plan: bool,
     pub family_members: Vec<Address>,
@@ -62,19 +66,19 @@ pub struct UserSubscription {
 #[derive(Clone)]
 #[contracttype]
 pub struct PausedSubscriptionData {
-    pub paused_at: u64,
-    pub remaining_days: u32,
+    pub paused_at: Timestamp,
+    pub remaining_days: DurationDays,
 }
 
 #[derive(Clone)]
 #[contracttype]
 pub struct GiftSubscription {
-    pub gift_id: u64,
+    pub gift_id: GiftId,
     pub from: Address,
     pub to: Address,
-    pub plan_id: u32,
+    pub plan_id: PlanId,
     pub claimed: bool,
-    pub created_at: u64,
+    pub created_at: Timestamp,
 }
 #[soroban_sdk::contracterror]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/contract/ticket_contract/Cargo.toml
+++ b/contract/ticket_contract/Cargo.toml
@@ -11,6 +11,7 @@ soroban-sdk = "23.5.2"
 stellar-access = "0.6.0"
 stellar-macros = "0.6.0"
 stellar-tokens = "0.6.0"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/ticket_contract/src/storage_types.rs
+++ b/contract/ticket_contract/src/storage_types.rs
@@ -1,4 +1,7 @@
 use soroban_sdk::{contracttype, Address, Bytes, String, Symbol};
+use gathera_common::types::{
+    Timestamp, TokenAmount, BasisPoints, DurationSeconds, LedgerSequence, DurationLedgers,
+};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -47,34 +50,36 @@ pub enum PricingStrategy {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PricingConfig {
     pub oracle_address: Address,
-    pub dex_pool_address: Address, // Fallback
-    pub price_floor: i128,
-    pub price_ceiling: i128,
-    pub update_frequency: u64, // Seconds
-    pub last_update_time: u64,
+    /// Fallback DEX pool address for price discovery.
+    pub dex_pool_address: Address,
+    pub price_floor: TokenAmount,
+    pub price_ceiling: TokenAmount,
+    /// Minimum seconds between price updates.
+    pub update_frequency: DurationSeconds,
+    pub last_update_time: Timestamp,
     pub is_frozen: bool,
     /// Asset pair string to query the oracle, e.g. "XLM/USD".
     pub oracle_pair: String,
     /// Reference baseline price from oracle (8 decimals) for computing the multiplier.
     /// Set this once at init time via a trusted first price; updated by `update_oracle_reference`.
-    pub oracle_reference_price: i128,
+    pub oracle_reference_price: TokenAmount,
     /// How old an oracle price can be (seconds) before we fall back to the DEX.
-    pub max_oracle_age_seconds: u64,
+    pub max_oracle_age_seconds: DurationSeconds,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EventInfo {
-    pub start_time: u64,
-    pub refund_cutoff_time: u64,
+    pub start_time: Timestamp,
+    pub refund_cutoff_time: Timestamp,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Tier {
     pub name: String,
-    pub base_price: i128,
-    pub current_price: i128,
+    pub base_price: TokenAmount,
+    pub current_price: TokenAmount,
     pub max_supply: u32,
     pub minted: u32,
     pub active: bool,
@@ -85,8 +90,8 @@ pub struct Tier {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Ticket {
     pub tier_symbol: Symbol,
-    pub purchase_time: u64,
-    pub price_paid: i128,
+    pub purchase_time: Timestamp,
+    pub price_paid: TokenAmount,
     pub is_valid: bool,
 }
 /// VRF-specific structures for ticket allocation
@@ -108,18 +113,18 @@ pub struct AllocationConfig {
     pub total_allocations: u32,
     pub allocated_count: u32,
     pub allocation_complete: bool,
-    pub finalization_ledger: u32,
-    pub reveal_start_ledger: u32,
-    pub reveal_end_ledger: u32,
+    pub finalization_ledger: LedgerSequence,
+    pub reveal_start_ledger: LedgerSequence,
+    pub reveal_end_ledger: LedgerSequence,
 }
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct AntiSnipingConfig {
-    pub minimum_lock_period: u32,
+    pub minimum_lock_period: DurationLedgers,
     pub max_entries_per_address: u32,
-    pub rate_limit_window: u64,
-    pub randomization_delay_ledgers: u32,
+    pub rate_limit_window: DurationSeconds,
+    pub randomization_delay_ledgers: DurationLedgers,
 }
 
 #[contracttype]
@@ -128,7 +133,7 @@ pub struct VRFState {
     pub randomness_generated: bool,
     pub randomness_hash: Bytes,
     pub batch_nonce: u32,
-    pub finalization_ledger: u32,
+    pub finalization_ledger: LedgerSequence,
 }
 #[soroban_sdk::contracterror]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/contract/vrf_contract/Cargo.toml
+++ b/contract/vrf_contract/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 soroban-sdk = "23.5.2"
 sha3 = "0.10.8"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/vrf_contract/src/storage_types.rs
+++ b/contract/vrf_contract/src/storage_types.rs
@@ -1,4 +1,7 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map, U256};
+use gathera_common::types::{
+    Timestamp, DurationSeconds, ReputationScore, ProviderWeight, TokenAmount,
+};
 
 #[derive(Clone)]
 pub enum DataKey {
@@ -20,8 +23,8 @@ pub struct VRFRequest {
     pub requester: Address,
     pub seed: BytesN<32>,
     pub additional_data: Vec<u8>,
-    pub created_at: u64,
-    pub fulfilled_at: Option<u64>,
+    pub created_at: Timestamp,
+    pub fulfilled_at: Option<Timestamp>,
     pub status: VRFStatus,
     pub proof: Option<VRFProof>,
     pub randomness_output: Option<BytesN<32>>,
@@ -46,7 +49,7 @@ pub struct VRFProof {
     pub s: BytesN<32>,
     pub verification_hash: BytesN<32>,
     pub provider: Address,
-    pub created_at: u64,
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone)]
@@ -54,13 +57,14 @@ pub struct EntropyProvider {
     pub address: Address,
     pub provider_type: ProviderType,
     pub public_key: BytesN<32>,
-    pub reputation_score: u32,
+    pub reputation_score: ReputationScore,
     pub success_count: u32,
     pub failure_count: u32,
-    pub last_used: u64,
+    pub last_used: Timestamp,
     pub active: bool,
-    pub weight: u32,
-    pub fee: i128,
+    pub weight: ProviderWeight,
+    /// Fee charged per VRF request in the smallest token unit.
+    pub fee: TokenAmount,
 }
 
 #[derive(Clone, PartialEq)]
@@ -76,7 +80,7 @@ pub struct RandomnessSeed {
     pub current_seed: BytesN<32>,
     pub previous_seed: BytesN<32>,
     pub block_number: u64,
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
     pub entropy_sources: Vec<EntropySource>,
     pub quality_score: f32,
 }
@@ -85,8 +89,8 @@ pub struct RandomnessSeed {
 pub struct EntropySource {
     pub source_type: SourceType,
     pub value: BytesN<32>,
-    pub weight: u32,
-    pub timestamp: u64,
+    pub weight: ProviderWeight,
+    pub timestamp: Timestamp,
     pub reliability: f32,
 }
 
@@ -108,7 +112,7 @@ pub struct RandomnessValidation {
     pub test_results: Vec<TestResult>,
     pub overall_score: f32,
     pub passed: bool,
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
     pub validator: Address,
 }
 
@@ -124,10 +128,10 @@ pub struct TestResult {
 pub struct QualityMetrics {
     pub total_requests: u32,
     pub successful_requests: u32,
-    pub average_response_time: u64,
+    pub average_response_time: DurationSeconds,
     pub randomness_quality_score: f32,
     pub provider_diversity: f32,
-    pub last_updated: u64,
+    pub last_updated: Timestamp,
 }
 
 #[derive(Clone)]
@@ -135,9 +139,9 @@ pub struct ProviderStats {
     pub provider: Address,
     pub total_requests: u32,
     pub successful_requests: u32,
-    pub average_response_time: u64,
-    pub reputation_history: Vec<u32>,
-    pub last_updated: u64,
+    pub average_response_time: DurationSeconds,
+    pub reputation_history: Vec<ReputationScore>,
+    pub last_updated: Timestamp,
 }
 
 // Custom errors

--- a/contract/zk_ticket_contract/Cargo.toml
+++ b/contract/zk_ticket_contract/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "23.5.2"
+gathera-common = { path = "../common" }
 
 [dev-dependencies]
 soroban-sdk = { version = "23.5.2", features = ["testutils"] }

--- a/contract/zk_ticket_contract/src/storage_types.rs
+++ b/contract/zk_ticket_contract/src/storage_types.rs
@@ -1,4 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec, Map, U256};
+use gathera_common::types::Timestamp;
 
 /// Storage keys for the ZK Ticket Contract.
 #[derive(Clone)]
@@ -49,11 +50,11 @@ pub struct ZKProof {
     /// Hash of the verification parameters for integrity.
     pub verification_hash: BytesN<32>,
     /// Timestamp when the proof was submitted.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Timestamp when verification was completed.
-    pub verified_at: Option<u64>,
+    pub verified_at: Option<Timestamp>,
     /// Expiration timestamp for this proof.
-    pub expires_at: u64,
+    pub expires_at: Timestamp,
     /// Flag indicating if the proof has been revoked.
     pub revoked: bool,
     /// ID of the batch this proof was verified in, if any.
@@ -106,7 +107,7 @@ pub struct TicketCommitment {
     /// Hash of the base ticket data.
     pub ticket_hash: BytesN<32>,
     /// Creation timestamp.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// The nullifier that will be revealed upon use.
     pub nullifier: BytesN<32>,
     /// Combined hash of all attribute commitments.
@@ -123,7 +124,7 @@ pub struct NullifierInfo {
     /// Whether this nullifier has been used (revealed).
     pub used: bool,
     /// When the nullifier was used.
-    pub used_at: Option<u64>,
+    pub used_at: Option<Timestamp>,
     /// The proof ID that revealed this nullifier.
     pub proof_id: Option<BytesN<32>>,
 }
@@ -140,8 +141,7 @@ pub struct EventCommitments {
     /// Number of tickets currently active.
     pub active_tickets: u32,
     /// Registration timestamp.
-    pub created_at: u64,
-    /// Circuit parameters specifically for this event's tickets.
+    pub created_at: Timestamp,
     pub circuit_params: CircuitParameters,
 }
 
@@ -170,7 +170,7 @@ pub struct VerificationCache {
     /// Result of the verification (true = valid).
     pub result: bool,
     /// Timestamp when the result was cached.
-    pub timestamp: u64,
+    pub timestamp: Timestamp,
     /// ID of the proof being cached.
     pub proof_id: BytesN<32>,
 }
@@ -183,7 +183,7 @@ pub struct RevocationList {
     /// Nullifiers associated with revoked tickets.
     pub revoked_nullifiers: Vec<BytesN<32>>,
     /// Last update timestamp.
-    pub last_updated: u64,
+    pub last_updated: Timestamp,
 }
 
 /// Status and data for a batch verification operation.
@@ -196,9 +196,9 @@ pub struct BatchVerification {
     /// Parallel list of verification results.
     pub results: Vec<bool>,
     /// Initiation timestamp.
-    pub created_at: u64,
+    pub created_at: Timestamp,
     /// Completion timestamp.
-    pub completed_at: Option<u64>,
+    pub completed_at: Option<Timestamp>,
     /// Current status of the batch.
     pub status: BatchStatus,
 }
@@ -224,7 +224,7 @@ pub struct MobileProofData {
     /// Template used for mobile-optimized proofs.
     pub proof_template: Vec<u8>,
     /// Last usage timestamp.
-    pub last_used: u64,
+    pub last_used: Timestamp,
     /// Total number of proofs verified for this device.
     pub usage_count: u32,
 }


### PR DESCRIPTION
- Add contract/common/src/types.rs with centralized type alias registry: Timestamp, LedgerSequence, TokenAmount, BasisPoints, Percentage, ProposalId, PlanId, SubscriptionId, GiftId, ClaimId, MilestoneId, TierId, CategoryId, SignerWeight, DurationSeconds, DurationDays, DurationLedgers, ReputationScore, ProviderWeight

- Re-export types module from gathera-common crate (lib.rs)

- Add gathera-common dependency to 6 contracts that were missing it: governance, subscription, ticket, vrf, zk_ticket, identity, feature_flag

- Update storage_types/storage files across all 10 contracts: governance_contract: ProposalId, CategoryId, Timestamp, LedgerSequence, TokenAmount, BasisPoints, Percentage subscription_contract: PlanId, SubscriptionId, GiftId, Timestamp, DurationDays, TokenAmount ticket_contract: Timestamp, TokenAmount, BasisPoints, DurationSeconds, LedgerSequence, DurationLedgers vrf_contract: Timestamp, DurationSeconds, ReputationScore, ProviderWeight, TokenAmount zk_ticket_contract: Timestamp (all time fields); restored missing BatchVerification doc comment identity_contract: Timestamp, ReputationScore, ClaimId dutch_auction_contract: Timestamp, TokenAmount, DurationSeconds escrow_contract: Timestamp, TokenAmount, Percentage, MilestoneId, DurationSeconds multisig_wallet_contract: Timestamp, TokenAmount, DurationSeconds, SignerWeight contracts/types.rs (staking): Timestamp, TokenAmount, DurationSeconds, TierId feature_flag_contract: Timestamp

Closes: #291 