### PR TITLE
refactor: decompose large functions across all 7 contracts

### DIFF
--- a/contract/dutch_auction_contract/src/lib.rs
+++ b/contract/dutch_auction_contract/src/lib.rs
@@ -64,14 +64,14 @@ impl DutchAuctionContract {
         anti_bot_enabled: Option<bool>,
         min_bid_increment: Option<i128>,
     ) -> BytesN<32> {
-        if is_paused(&e) {
+        if is_paused(&env) {
             panic!("contract is paused");
         }
 
         organizer.require_auth();
 
         // Validate auction parameters
-        Self::validate_auction_params(&env, initial_price, reserve_price, floor_price, decay_constant, duration, total_tickets)?;
+        Self::validate_auction_params(&env, initial_price, reserve_price, floor_price, decay_constant, duration, total_tickets);
 
         // Check concurrent auction limit
         let config: AuctionConfig = env.storage().instance().get(&DataKey::AuctionConfig).unwrap();
@@ -117,7 +117,7 @@ impl DutchAuctionContract {
 
         // Add to organizer's auctions
         let organizer_key = DataKey::UserAuctions(organizer.clone());
-        let mut organizer_auctions: Vec<BytesN<32>> = env.storage().persistent().get(&organizer_key).unwrap_or(Vec::new(&e));
+        let mut organizer_auctions: Vec<BytesN<32>> = env.storage().persistent().get(&organizer_key).unwrap_or(Vec::new(&env));
         organizer_auctions.push_back(auction_id.clone());
         env.storage().persistent().set(&organizer_key, &organizer_auctions);
 
@@ -172,7 +172,7 @@ impl DutchAuctionContract {
         }
 
         // Check rate limiting
-        Self::check_rate_limit(&env, &bidder, &auction)?;
+        Self::check_rate_limit(&env, &bidder, &auction).unwrap_or_else(|e| panic!("{:?}", e));
 
         // Store commitment
         auction.winner_commitments.set(bidder.clone(), commitment.clone());
@@ -227,7 +227,7 @@ impl DutchAuctionContract {
         }
 
         // Process the revealed bid
-        Self::process_bid(&env, &mut auction, &bidder, amount)?;
+        Self::process_bid(&env, &mut auction, &bidder, amount).unwrap_or_else(|e| panic!("{:?}", e));
 
         // Update commit-reveal data
         commit_reveal.revealed = true;
@@ -258,10 +258,10 @@ impl DutchAuctionContract {
         }
 
         // Check rate limiting
-        Self::check_rate_limit(&env, &bidder, &auction)?;
+        Self::check_rate_limit(&env, &bidder, &auction).unwrap_or_else(|e| panic!("{:?}", e));
 
         // Process the bid
-        Self::process_bid(&env, &mut auction, &bidder, amount)?;
+        Self::process_bid(&env, &mut auction, &bidder, amount).unwrap_or_else(|e| panic!("{:?}", e));
 
         // Update rate limiter
         Self::update_rate_limiter(&env, &bidder);
@@ -419,40 +419,38 @@ impl DutchAuctionContract {
     }
 
     fn validate_auction_params(
-        e: &Env,
+        env: &Env,
         initial_price: i128,
         reserve_price: i128,
         floor_price: i128,
         decay_constant: u32,
         duration: u64,
         total_tickets: u32,
-    ) -> Result<(), DutchAuctionError> {
+    ) {
         if initial_price <= 0 || reserve_price <= 0 || floor_price <= 0 {
-            return Err(DutchAuctionError::InvalidAmount);
+            panic!("invalid price values");
         }
 
         if reserve_price >= initial_price {
-            return Err(DutchAuctionError::BelowReservePrice);
+            panic!("reserve price must be below initial price");
         }
 
         if floor_price >= reserve_price {
-            return Err(DutchAuctionError::BelowFloorPrice);
+            panic!("floor price must be below reserve price");
         }
 
         if decay_constant == 0 {
-            return Err(DutchAuctionError::InvalidDecayConstant);
+            panic!("decay constant must be positive");
         }
 
         let config: AuctionConfig = env.storage().instance().get(&DataKey::AuctionConfig).unwrap();
         if duration < config.min_duration || duration > config.max_duration {
-            return Err(DutchAuctionError::InvalidTime);
+            panic!("duration out of allowed range");
         }
 
         if total_tickets == 0 {
-            return Err(DutchAuctionError::NoTicketsAvailable);
+            panic!("total tickets must be positive");
         }
-
-        Ok(())
     }
 
     fn calculate_price(initial_price: i128, floor_price: i128, decay_constant: u32, time_elapsed: u64) -> i128 {
@@ -499,20 +497,9 @@ impl DutchAuctionContract {
 
         // Get current price
         let current_price = Self::get_current_price(env.clone(), auction.id.clone());
-        
-        // Check if bid meets minimum price
-        if amount < current_price {
-            return Err(DutchAuctionError::BidTooLow);
-        }
 
-        // Check minimum bid increment
-        if !auction.bids.is_empty() {
-            let highest_bid = auction.bids.iter().map(|b| b.amount).max().unwrap();
-            let min_increment_bid = highest_bid.checked_add(auction.min_bid_increment).expect("Arithmetic overflow");
-            if amount < min_increment_bid {
-                return Err(DutchAuctionError::BidTooLow);
-            }
-        }
+        // Validate amount against current price and minimum bid increment
+        Self::validate_bid_amount(auction, amount, current_price)?;
 
         // Transfer tokens to contract
         let token_client = soroban_sdk::token::Client::new(env, &auction.token);
@@ -539,10 +526,7 @@ impl DutchAuctionContract {
         auction.current_price = current_price;
 
         // Check for auction extension
-        let extension_point = end_time.checked_sub(auction.extension_threshold).expect("Time error");
-        if env.ledger().timestamp() > extension_point {
-            auction.final_extension_time = auction.final_extension_time.checked_add(auction.extension_duration).expect("Time overflow");
-        }
+        Self::apply_auction_extension(auction, end_time, env.ledger().timestamp());
 
         // Add to user's bids
         let user_bids_key = DataKey::UserBids(bidder.clone());
@@ -551,6 +535,34 @@ impl DutchAuctionContract {
         env.storage().persistent().set(&user_bids_key, &user_bids);
 
         Ok(())
+    }
+
+    /// Validates that `amount` meets both the current price floor and the minimum bid increment.
+    fn validate_bid_amount(auction: &Auction, amount: i128, current_price: i128) -> Result<(), DutchAuctionError> {
+        if amount < current_price {
+            return Err(DutchAuctionError::BidTooLow);
+        }
+
+        if !auction.bids.is_empty() {
+            let highest_bid = auction.bids.iter().map(|b| b.amount).max().unwrap();
+            let min_increment_bid = highest_bid.checked_add(auction.min_bid_increment).expect("Arithmetic overflow");
+            if amount < min_increment_bid {
+                return Err(DutchAuctionError::BidTooLow);
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Extends the auction if the bid arrives within the anti-sniping threshold window.
+    fn apply_auction_extension(auction: &mut Auction, end_time: u64, current_time: u64) {
+        let extension_point = end_time.checked_sub(auction.extension_threshold).expect("Time error");
+        if current_time > extension_point {
+            auction.final_extension_time = auction
+                .final_extension_time
+                .checked_add(auction.extension_duration)
+                .expect("Time overflow");
+        }
     }
 
     fn check_rate_limit(env: &Env, bidder: &Address, auction: &Auction) -> Result<(), DutchAuctionError> {

--- a/contract/dutch_auction_contract/src/test.rs
+++ b/contract/dutch_auction_contract/src/test.rs
@@ -593,3 +593,29 @@ fn test_overflow_protection() {
     // If we use i128::MAX and large decay/time, it will overflow.
     DutchAuctionContract::calculate_price(i128::MAX, 1, u32::MAX, u64::MAX);
 }
+
+// ─── Tests for extracted helpers ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_calculate_price_returns_initial_at_zero_elapsed() {
+    // At t=0, price should equal initial_price.
+    let price = DutchAuctionContract::calculate_price(1_000_000, 100_000, 1_000, 0);
+    assert_eq!(price, 1_000_000);
+}
+
+#[test]
+fn test_calculate_price_returns_floor_when_decay_saturates() {
+    // With large elapsed time the price should converge to floor_price.
+    let floor = 100_000_i128;
+    let price = DutchAuctionContract::calculate_price(1_000_000, floor, 1_000_000, 1_000_000);
+    assert_eq!(price, floor);
+}
+
+#[test]
+fn test_calculate_price_decreasing() {
+    // Price should be strictly decreasing over time (before saturating).
+    let p0 = DutchAuctionContract::calculate_price(1_000_000, 10_000, 100, 0);
+    let p1 = DutchAuctionContract::calculate_price(1_000_000, 10_000, 100, 100);
+    let p2 = DutchAuctionContract::calculate_price(1_000_000, 10_000, 100, 200);
+    assert!(p0 >= p1 && p1 >= p2, "Price must be non-increasing over time");
+}

--- a/contract/escrow_contract/Cargo.toml
+++ b/contract/escrow_contract/Cargo.toml
@@ -20,7 +20,7 @@ testutils = ["soroban-sdk/testutils"]
 [profile.release]
 opt-level = "z"
 debug = 0
-strip = symbols
+strip = "symbols"
 debug-assertions = false
 overflow-checks = true
 lto = true

--- a/contract/escrow_contract/src/lib.rs
+++ b/contract/escrow_contract/src/lib.rs
@@ -587,20 +587,8 @@ impl EscrowContract {
         let contract_address = env.current_contract_address();
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
 
-        let organizer_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.organizer_percentage, escrow.revenue_splits.precision);
-        let platform_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.platform_percentage, escrow.revenue_splits.precision);
-        let mut referral_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.referral_percentage, escrow.revenue_splits.precision);
-
-        // Adjust for rounding
-        let total_splits = organizer_amount
-            .checked_add(platform_amount)
-            .and_then(|val| val.checked_add(referral_amount))
-            .expect("Arithmetic overflow in total splits");
-
-        if total_splits > escrow.amount {
-            let diff = total_splits.checked_sub(escrow.amount).expect("Arithmetic error");
-            referral_amount = referral_amount.checked_sub(diff).expect("Arithmetic error");
-        }
+        let (organizer_amount, platform_amount, referral_amount) =
+            Self::compute_revenue_splits(escrow);
 
         // Transfer funds
         token_client.transfer(&contract_address, &escrow.organizer, &organizer_amount);
@@ -619,15 +607,8 @@ impl EscrowContract {
         let contract_address = env.current_contract_address();
         let admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
 
-        let organizer_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.organizer_percentage, escrow.revenue_splits.precision);
-        let platform_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.platform_percentage, escrow.revenue_splits.precision);
-        let mut referral_amount = Self::calculate_split(escrow.amount, escrow.revenue_splits.referral_percentage, escrow.revenue_splits.precision);
-
-        // Adjust for rounding
-        let total_splits = organizer_amount + platform_amount + referral_amount;
-        if total_splits > escrow.amount {
-            referral_amount -= (total_splits - escrow.amount);
-        }
+        let (organizer_amount, platform_amount, referral_amount) =
+            Self::compute_revenue_splits(escrow);
 
         // Transfer funds with error handling
         if let Err(_) = token_client.try_transfer(&contract_address, &escrow.organizer, &organizer_amount) {
@@ -647,6 +628,40 @@ impl EscrowContract {
         }
 
         Ok(())
+    }
+
+    /// Computes the three-way revenue split (organizer, platform, referral) for a given escrow,
+    /// adjusting for rounding so that the total never exceeds `escrow.amount`.
+    /// Returns `(organizer_amount, platform_amount, referral_amount)`.
+    pub(crate) fn compute_revenue_splits(escrow: &Escrow) -> (i128, i128, i128) {
+        let organizer_amount = Self::calculate_split(
+            escrow.amount,
+            escrow.revenue_splits.organizer_percentage,
+            escrow.revenue_splits.precision,
+        );
+        let platform_amount = Self::calculate_split(
+            escrow.amount,
+            escrow.revenue_splits.platform_percentage,
+            escrow.revenue_splits.precision,
+        );
+        let mut referral_amount = Self::calculate_split(
+            escrow.amount,
+            escrow.revenue_splits.referral_percentage,
+            escrow.revenue_splits.precision,
+        );
+
+        // Adjust for rounding: never distribute more than the total amount
+        let total_splits = organizer_amount
+            .checked_add(platform_amount)
+            .and_then(|val| val.checked_add(referral_amount))
+            .expect("Arithmetic overflow in total splits");
+
+        if total_splits > escrow.amount {
+            let diff = total_splits.checked_sub(escrow.amount).expect("Arithmetic error");
+            referral_amount = referral_amount.checked_sub(diff).expect("Arithmetic error");
+        }
+
+        (organizer_amount, platform_amount, referral_amount)
     }
 
     fn track_referral(env: &Env, referrer: &Address, purchaser: &Address) {

--- a/contract/escrow_contract/src/test.rs
+++ b/contract/escrow_contract/src/test.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
-use crate::{EscrowContract, EscrowStatus, RevenueSplit, Milestone, RevenueSplitConfig, ReferralTracker};
+use crate::{EscrowContract, EscrowStatus, Escrow, RevenueSplit, Milestone, RevenueSplitConfig, ReferralTracker};
 
 #[test]
 fn test_initialize() {
@@ -346,4 +346,67 @@ fn test_dispute_creation_and_resolution() {
     let escrow = EscrowContract::get_escrow(env.clone(), escrow_id);
     assert_eq!(escrow.status, EscrowStatus::Disputed);
     assert!(!escrow.dispute_active);
+}
+
+// ─── Tests for extracted compute_revenue_splits helper ─────────────────────────────────
+
+fn make_escrow(env: &Env, amount: i128, org_pct: u32, plat_pct: u32, ref_pct: u32, precision: u32) -> Escrow {
+    let organizer = Address::generate(env);
+    let purchaser = Address::generate(env);
+    let event = Address::generate(env);
+    let token = Address::generate(env);
+    Escrow {
+        id: BytesN::from_array(env, &[0; 32]),
+        event,
+        organizer,
+        purchaser,
+        amount,
+        token,
+        created_at: 0,
+        release_time: 0,
+        status: EscrowStatus::Pending,
+        revenue_splits: RevenueSplit {
+            organizer_percentage: org_pct,
+            platform_percentage: plat_pct,
+            referral_percentage: ref_pct,
+            precision,
+        },
+        referral: None,
+        milestones: Vec::new(env),
+        dispute_active: false,
+    }
+}
+
+#[test]
+fn test_compute_revenue_splits_sums_to_amount() {
+    // All three amounts must sum exactly to the total (precision = 100).
+    let env = Env::default();
+    // 70% org, 20% plat, 10% ref, precision=100
+    let escrow = make_escrow(&env, 1000, 70, 20, 10, 100);
+    let (org, plat, referral) = EscrowContract::compute_revenue_splits(&escrow);
+    assert_eq!(org + plat + referral, escrow.amount);
+    assert_eq!(org, 700);
+    assert_eq!(plat, 200);
+    assert_eq!(referral, 100);
+}
+
+#[test]
+fn test_compute_revenue_splits_rounding_adjustment() {
+    // With amounts that don’t divide evenly, the referral slice absorbs rounding.
+    let env = Env::default();
+    // 70% org, 20% plat, 10% ref, precision=100, amount=101
+    let escrow = make_escrow(&env, 101, 70, 20, 10, 100);
+    let (org, plat, referral) = EscrowContract::compute_revenue_splits(&escrow);
+    // Total must not exceed 101
+    assert!(org + plat + referral <= escrow.amount);
+}
+
+#[test]
+fn test_compute_revenue_splits_no_referral() {
+    // When referral_percentage is 0, referral_amount is 0 and others sum correctly.
+    let env = Env::default();
+    let escrow = make_escrow(&env, 1000, 80, 20, 0, 100);
+    let (org, plat, referral) = EscrowContract::compute_revenue_splits(&escrow);
+    assert_eq!(referral, 0);
+    assert_eq!(org + plat, escrow.amount);
 }

--- a/contract/governance_contract/src/lib.rs
+++ b/contract/governance_contract/src/lib.rs
@@ -179,43 +179,27 @@ impl GovernanceContract {
         let mut total_power: i128 = 0;
 
         // Voter's own power
-        if !env.storage().persistent().has(&DataKey::Vote(proposal_id, voter.clone())) {
-            let balance = token_client.balance(&voter);
-            let power = if use_quadratic { Self::sqrt(balance) } else { balance };
-            total_power = total_power.checked_add(power).expect("Power overflow");
-            
-            env.storage().persistent().set(&DataKey::Vote(proposal_id, voter.clone()), &VoteRecord {
-                voter: voter.clone(),
-                support,
-                amount: power,
-                is_quadratic: use_quadratic,
-            });
-        }
+        let own_power = Self::cast_single_vote(
+            &env, proposal_id, &voter, &voter, support, use_quadratic, &token_client,
+        );
+        total_power = total_power.checked_add(own_power).expect("Power overflow");
 
         // Delegators' power
         for delegator in delegators.iter() {
-            let delegatee: Address = env.storage().persistent().get(&DataKey::UserDelegation(delegator.clone()))
+            let delegatee: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::UserDelegation(delegator.clone()))
                 .expect("Not a delegatee for this user");
-            
+
             if delegatee != voter {
                 panic!("Invalid delegatee for one of the delegators");
             }
 
-            if env.storage().persistent().has(&DataKey::Vote(proposal_id, delegator.clone())) {
-                continue;
-            }
-
-            let balance = token_client.balance(&delegator);
-            let power = if use_quadratic { Self::sqrt(balance) } else { balance };
-            
-            total_power = total_power.checked_add(power).expect("Power overflow");
-
-            env.storage().persistent().set(&DataKey::Vote(proposal_id, delegator.clone()), &VoteRecord {
-                voter: voter.clone(),
-                support,
-                amount: power,
-                is_quadratic: use_quadratic,
-            });
+            let delegator_power = Self::cast_single_vote(
+                &env, proposal_id, &delegator, &voter, support, use_quadratic, &token_client,
+            );
+            total_power = total_power.checked_add(delegator_power).expect("Power overflow");
         }
 
         if support {
@@ -273,24 +257,15 @@ impl GovernanceContract {
             ProposalCategory::Emergency => 3,
         };
 
-        let settings: CategorySettings = env.storage().instance().get(&DataKey::CategorySettings(category_id))
+        let settings: CategorySettings = env
+            .storage()
+            .instance()
+            .get(&DataKey::CategorySettings(category_id))
             .expect("Settings not found");
 
-        let total_votes = proposal.total_votes_for.checked_add(proposal.total_votes_against).expect("Votes overflow");
-        if total_votes >= settings.quorum {
-            let for_percentage = if total_votes > 0 { 
-                (proposal.total_votes_for.checked_mul(100).expect("Arithmetic error")).checked_div(total_votes).expect("Arithmetic error")
-            } else { 0 };
-            if for_percentage >= settings.threshold as i128 {
-                proposal.status = ProposalStatus::Queued;
-                let timelock: u64 = env.storage().instance().get(&DataKey::TimelockDuration).unwrap();
-                proposal.eta = env.ledger().timestamp().checked_add(timelock).expect("Time overflow");
-            } else {
-                proposal.status = ProposalStatus::Defeated;
-            }
-        } else {
-            proposal.status = ProposalStatus::Defeated;
-        }
+        let (new_status, eta) = Self::evaluate_proposal_outcome(&env, &proposal, &settings);
+        proposal.status = new_status;
+        proposal.eta = eta;
 
         env.storage().persistent().set(&DataKey::Proposal(proposal_id), &proposal);
 
@@ -331,6 +306,74 @@ impl GovernanceContract {
         }
 
         env.events().publish((symbol_short!("emergen"),), action);
+    }
+
+    /// Records a single vote for `voter` on behalf of `actual_voter` (the authorised caller).
+    /// Returns the voting power added, or `0` if the address had already voted.
+    fn cast_single_vote(
+        env: &Env,
+        proposal_id: u32,
+        voter: &Address,
+        actual_voter: &Address,
+        support: bool,
+        use_quadratic: bool,
+        token_client: &token::Client,
+    ) -> i128 {
+        if env.storage().persistent().has(&DataKey::Vote(proposal_id, voter.clone())) {
+            return 0;
+        }
+        let balance = token_client.balance(voter);
+        let power = if use_quadratic { Self::sqrt(balance) } else { balance };
+        env.storage().persistent().set(
+            &DataKey::Vote(proposal_id, voter.clone()),
+            &VoteRecord {
+                voter: actual_voter.clone(),
+                support,
+                amount: power,
+                is_quadratic: use_quadratic,
+            },
+        );
+        power
+    }
+
+    /// Determines the outcome of a proposal based on quorum and approval threshold.
+    /// Returns the new `(ProposalStatus, eta)` tuple; `eta` is non-zero only when queued.
+    fn evaluate_proposal_outcome(
+        env: &Env,
+        proposal: &Proposal,
+        settings: &CategorySettings,
+    ) -> (ProposalStatus, u64) {
+        let total_votes = proposal
+            .total_votes_for
+            .checked_add(proposal.total_votes_against)
+            .expect("Votes overflow");
+
+        if total_votes < settings.quorum {
+            return (ProposalStatus::Defeated, 0);
+        }
+
+        let for_percentage = if total_votes > 0 {
+            proposal
+                .total_votes_for
+                .checked_mul(100)
+                .expect("Arithmetic error")
+                .checked_div(total_votes)
+                .expect("Arithmetic error")
+        } else {
+            0
+        };
+
+        if for_percentage >= settings.threshold as i128 {
+            let timelock: u64 = env.storage().instance().get(&DataKey::TimelockDuration).unwrap();
+            let eta = env
+                .ledger()
+                .timestamp()
+                .checked_add(timelock)
+                .expect("Time overflow");
+            (ProposalStatus::Queued, eta)
+        } else {
+            (ProposalStatus::Defeated, 0)
+        }
     }
 
     fn sqrt(n: i128) -> i128 {

--- a/contract/governance_contract/src/test.rs
+++ b/contract/governance_contract/src/test.rs
@@ -174,6 +174,155 @@ fn test_delegation() {
 }
 
 #[test]
+fn test_double_vote_guard() {
+    // Voting twice for the same proposal should not double-count power.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let emergency = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract(token_admin.clone());
+    let token_client = token::StellarAssetClient::new(&env, &token_addr);
+
+    token_client.mint(&proposer, &500);
+    token_client.mint(&voter, &300);
+
+    let contract_id = env.register(GovernanceContract, ());
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.init(&admin, &token_addr, &100, &emergency);
+
+    let action = GovernanceAction::FeeChange(10);
+    let prop_id = client.create_proposal(
+        &proposer,
+        &action,
+        &ProposalCategory::FeeAdjustment,
+        &String::from_str(&env, "Desc"),
+    );
+
+    // Vote once
+    client.vote(&voter, &prop_id, &true, &false, &Vec::new(&env));
+    let prop_after_first = client.get_proposal(&prop_id);
+    let votes_after_first = prop_after_first.total_votes_for;
+
+    // Vote again — should be a no-op (guard prevents double counting)
+    client.vote(&voter, &prop_id, &true, &false, &Vec::new(&env));
+    let prop_after_second = client.get_proposal(&prop_id);
+
+    assert_eq!(
+        prop_after_second.total_votes_for, votes_after_first,
+        "Double vote should not increase total power"
+    );
+}
+
+#[test]
+fn test_queue_defeated_below_quorum() {
+    // Proposals with total votes below quorum should always be Defeated.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let emergency = Address::generate(&env);
+    let proposer = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract(token_admin.clone());
+    let token_client = token::StellarAssetClient::new(&env, &token_addr);
+    token_client.mint(&proposer, &500);
+
+    let contract_id = env.register(GovernanceContract, ());
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.init(&admin, &token_addr, &100, &emergency);
+
+    let action = GovernanceAction::FeeChange(10);
+    let prop_id = client.create_proposal(
+        &proposer,
+        &action,
+        &ProposalCategory::FeeAdjustment,
+        &String::from_str(&env, "Desc"),
+    );
+
+    // No votes cast — total is 0, which is below any quorum
+
+    use soroban_sdk::testutils::LedgerInfo;
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp(),
+        protocol_version: 21,
+        sequence_number: env.ledger().sequence() + 51,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 1000,
+        min_persistent_entry_ttl: 1000,
+        min_temp_entry_ttl: 1000,
+    });
+
+    client.queue(&prop_id);
+    let prop = client.get_proposal(&prop_id);
+    if let ProposalStatus::Defeated = prop.status {} else {
+        panic!("Proposal should be Defeated when below quorum");
+    }
+}
+
+#[test]
+fn test_queue_defeated_below_threshold() {
+    // Meets quorum but NOT the approval threshold -> Defeated.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let emergency = Address::generate(&env);
+    let proposer = Address::generate(&env);
+    let voter_for = Address::generate(&env);
+    let voter_against = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_addr = env.register_stellar_asset_contract(token_admin.clone());
+    let token_client = token::StellarAssetClient::new(&env, &token_addr);
+    token_client.mint(&proposer, &500);
+    token_client.mint(&voter_for, &200);
+    token_client.mint(&voter_against, &400);
+
+    let contract_id = env.register(GovernanceContract, ());
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    client.init(&admin, &token_addr, &100, &emergency);
+
+    // Lower quorum so both voters push past it
+    client.set_category_settings(&1, &100, &50, &50);
+
+    let action = GovernanceAction::FeeChange(10);
+    let prop_id = client.create_proposal(
+        &proposer,
+        &action,
+        &ProposalCategory::FeeAdjustment,
+        &String::from_str(&env, "Desc"),
+    );
+
+    client.vote(&voter_for, &prop_id, &true, &false, &Vec::new(&env));   // 200 for
+    client.vote(&voter_against, &prop_id, &false, &false, &Vec::new(&env)); // 400 against
+
+    use soroban_sdk::testutils::LedgerInfo;
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp(),
+        protocol_version: 21,
+        sequence_number: env.ledger().sequence() + 51,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 1000,
+        min_persistent_entry_ttl: 1000,
+        min_temp_entry_ttl: 1000,
+    });
+
+    client.queue(&prop_id);
+    let prop = client.get_proposal(&prop_id);
+    if let ProposalStatus::Defeated = prop.status {} else {
+        panic!("Proposal should be Defeated when below approval threshold");
+    }
+}
+
+#[test]
 fn test_emergency_procedures() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contract/subscription_contract/src/lib.rs
+++ b/contract/subscription_contract/src/lib.rs
@@ -124,22 +124,7 @@ impl SubscriptionContract {
         subscription::process_subscription_payment(&env, &user, &plan);
 
         let subscription_id: u64 = env.storage().instance().get(&DataKey::NextSubscriptionId).unwrap();
-        let current_time = env.ledger().timestamp();
-        let duration_seconds = (plan.duration_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
-        let end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
-
-        let subscription = UserSubscription {
-            subscription_id,
-            user: user.clone(),
-            plan_id,
-            status: SubscriptionStatus::Active,
-            start_date: current_time,
-            end_date,
-            last_payment_date: current_time,
-            auto_renew: true,
-            is_family_plan: false,
-            family_members: Vec::new(&env),
-        };
+        let subscription = Self::build_user_subscription(&env, user.clone(), plan_id, subscription_id, &plan, true);
 
         env.storage().persistent().set(&DataKey::UserSubscription(user.clone()), &subscription);
         let next_sub_id = subscription_id.checked_add(1).expect("ID overflow");
@@ -151,7 +136,7 @@ impl SubscriptionContract {
                 subscription_id,
                 user,
                 plan_id,
-                end_date,
+                end_date: subscription.end_date,
             },
         );
 
@@ -529,22 +514,14 @@ impl SubscriptionContract {
             .expect("Plan not found");
 
         let subscription_id: u64 = env.storage().instance().get(&DataKey::NextSubscriptionId).unwrap();
-        let current_time = env.ledger().timestamp();
-        let duration_seconds = (plan.duration_days as u64).checked_mul(SECONDS_PER_DAY).expect("Time overflow");
-        let end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
-
-        let subscription = UserSubscription {
+        let subscription = Self::build_user_subscription(
+            &env,
+            user.clone(),
+            gift.plan_id,
             subscription_id,
-            user: user.clone(),
-            plan_id: gift.plan_id,
-            status: SubscriptionStatus::Active,
-            start_date: current_time,
-            end_date,
-            last_payment_date: current_time,
-            auto_renew: false,
-            is_family_plan: false,
-            family_members: Vec::new(&env),
-        };
+            &plan,
+            false, // gifted subscriptions default to no auto-renew
+        );
 
         gift.claimed = true;
 
@@ -559,7 +536,7 @@ impl SubscriptionContract {
                 subscription_id,
                 user,
                 plan_id: gift.plan_id,
-                end_date,
+                end_date: subscription.end_date,
             },
         );
 
@@ -648,5 +625,35 @@ impl SubscriptionContract {
         // This would need to iterate through all subscriptions to find if member is in any family plan
         // For efficiency, consider maintaining a reverse index in production
         false
+    }
+
+    /// Builds a new [`UserSubscription`] from a plan, assigning the given ID.
+    /// `auto_renew` is caller-controlled (direct purchase vs. gift claim differ here).
+    fn build_user_subscription(
+        env: &Env,
+        user: Address,
+        plan_id: u32,
+        subscription_id: u64,
+        plan: &SubscriptionPlan,
+        auto_renew: bool,
+    ) -> UserSubscription {
+        let current_time = env.ledger().timestamp();
+        let duration_seconds = (plan.duration_days as u64)
+            .checked_mul(SECONDS_PER_DAY)
+            .expect("Time overflow");
+        let end_date = current_time.checked_add(duration_seconds).expect("Time overflow");
+
+        UserSubscription {
+            subscription_id,
+            user,
+            plan_id,
+            status: SubscriptionStatus::Active,
+            start_date: current_time,
+            end_date,
+            last_payment_date: current_time,
+            auto_renew,
+            is_family_plan: false,
+            family_members: Vec::new(env),
+        }
     }
 }

--- a/contract/subscription_contract/src/test.rs
+++ b/contract/subscription_contract/src/test.rs
@@ -494,3 +494,134 @@ fn test_update_plan() {
     assert_eq!(plan.price, 1500);
     assert_eq!(plan.category_ids.len(), 5);
 }
+
+// ─── Tests for refactored helpers ─────────────────────────────────────────────────────
+
+#[test]
+fn test_subscribe_duplicate_blocks() {
+    // Subscribing twice while already active must panic.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let contract = create_subscription_contract(&env);
+
+    token.mint(&user, &20000);
+    contract.initialize(&admin, &token.address, &7);
+
+    let category_ids = Vec::from_array(&env, [1u32]);
+    let plan_id = contract.create_plan(&SubscriptionTier::Monthly, &1000, &30, &category_ids, &0);
+
+    contract.subscribe(&user, &plan_id);
+
+    // Second subscribe should panic
+    let result = std::panic::catch_unwind(|| {
+        contract.subscribe(&user, &plan_id);
+    });
+    assert!(result.is_err(), "Subscribing twice should fail");
+}
+
+#[test]
+fn test_claim_gift_sets_auto_renew_false() {
+    // Gifts should create subscriptions with auto_renew = false.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let gifter = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let contract = create_subscription_contract(&env);
+
+    token.mint(&gifter, &10000);
+    contract.initialize(&admin, &token.address, &7);
+
+    let category_ids = Vec::from_array(&env, [1u32]);
+    let plan_id = contract.create_plan(&SubscriptionTier::Monthly, &1000, &30, &category_ids, &0);
+
+    let gift_id = contract.gift_subscription(&gifter, &recipient, &plan_id);
+    let sub_id = contract.claim_gift(&recipient, &gift_id);
+
+    let sub = contract.get_subscription(&recipient).unwrap();
+    assert_eq!(sub.subscription_id, sub_id);
+    assert!(!sub.auto_renew, "Gifted subscription should have auto_renew = false");
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+}
+
+#[test]
+fn test_check_subscription_status_expires_to_grace() {
+    // When a subscription passes end_date but not grace period end, it should become GracePeriod.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let contract = create_subscription_contract(&env);
+
+    token.mint(&user, &10000);
+    // 7-day grace period
+    contract.initialize(&admin, &token.address, &7);
+
+    let category_ids = Vec::from_array(&env, [1u32]);
+    // 30-day plan
+    let plan_id = contract.create_plan(&SubscriptionTier::Monthly, &1000, &30, &category_ids, &0);
+    contract.subscribe(&user, &plan_id);
+
+    // Advance ledger past end_date but within grace period (35 days = 30 plan + 5 days into grace)
+    let thirty_five_days = 35u64 * 86_400;
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + thirty_five_days,
+        protocol_version: 21,
+        sequence_number: env.ledger().sequence() + 100,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 10000,
+        min_persistent_entry_ttl: 10000,
+        min_temp_entry_ttl: 10000,
+    });
+
+    let status = contract.check_subscription_status(&user);
+    assert_eq!(status, SubscriptionStatus::GracePeriod);
+}
+
+#[test]
+fn test_check_subscription_status_expires_fully() {
+    // Past grace period -> Expired.
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let token = create_token_contract(&env, &token_admin);
+    let contract = create_subscription_contract(&env);
+
+    token.mint(&user, &10000);
+    contract.initialize(&admin, &token.address, &7);
+
+    let category_ids = Vec::from_array(&env, [1u32]);
+    let plan_id = contract.create_plan(&SubscriptionTier::Monthly, &1000, &30, &category_ids, &0);
+    contract.subscribe(&user, &plan_id);
+
+    // Advance 40 days (30 plan + 7 grace + 3 extra)
+    let forty_days = 40u64 * 86_400;
+    env.ledger().set(LedgerInfo {
+        timestamp: env.ledger().timestamp() + forty_days,
+        protocol_version: 21,
+        sequence_number: env.ledger().sequence() + 100,
+        network_id: [0u8; 32],
+        base_reserve: 10,
+        max_entry_ttl: 10000,
+        min_persistent_entry_ttl: 10000,
+        min_temp_entry_ttl: 10000,
+    });
+
+    let status = contract.check_subscription_status(&user);
+    assert_eq!(status, SubscriptionStatus::Expired);
+}

--- a/contract/ticket_contract/src/lib.rs
+++ b/contract/ticket_contract/src/lib.rs
@@ -665,43 +665,13 @@ impl SoulboundTicketContract {
             return tier.current_price;
         }
 
-        // Base price
-        let mut price = tier.base_price;
-
-        // Apply strategy variations
-        match tier.strategy {
-            PricingStrategy::Standard => {
-                // Demand based: base_price * (1 + (minted / (max_supply / 5)) * 5%)
-                let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
-                let multiplier = (thresholds_passed as i128).checked_mul(PRICE_INCREASE_BPS).expect("Arithmetic overflow");
-                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
-                price = price.checked_add(increase).expect("Arithmetic overflow");
-            }
-            PricingStrategy::TimeDecay => {
-                let event_info: EventInfo =
-                    e.storage().instance().get(&DataKey::EventInfo).unwrap();
-                let now = e.ledger().timestamp();
-                // If purchased way before event, apply 10% discount
-                // Assume linear scale from start to event_start_time
-                let start = event_info.start_time.saturating_sub(ONE_WEEK_SECONDS); // 1 week before
-                if now < start {
-                    let discount = price.checked_mul(EARLY_BIRD_DISCOUNT_BPS).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
-                    price = price.checked_sub(discount).expect("Arithmetic overflow");
-                }
-            }
-            PricingStrategy::AbTestA => {
-                // High demand sensitivity (10% increase per threshold)
-                let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
-                let multiplier = (thresholds_passed as i128).checked_mul(PRICE_INCREASE_BPS * 2).expect("Arithmetic overflow");
-                let increase = price.checked_mul(multiplier).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
-                price = price.checked_add(increase).expect("Arithmetic overflow");
-            }
-            PricingStrategy::AbTestB => {
-                // Floor starts higher (+20%)
-                let uplift = price.checked_mul(AB_TEST_B_FLOOR_UPLIFT_BPS).and_then(|v| v.checked_div(BPS_PRECISION)).expect("Arithmetic overflow");
-                price = price.checked_add(uplift).expect("Arithmetic overflow");
-            }
-        }
+        // Apply strategy-specific price adjustment
+        let mut price = match tier.strategy {
+            PricingStrategy::Standard => Self::apply_standard_pricing(tier.base_price, &tier),
+            PricingStrategy::TimeDecay => Self::apply_time_decay_pricing(e, tier.base_price, &tier),
+            PricingStrategy::AbTestA => Self::apply_ab_test_a_pricing(tier.base_price, &tier),
+            PricingStrategy::AbTestB => Self::apply_ab_test_b_pricing(tier.base_price),
+        };
 
         // Apply external Oracle factors using the real DIA oracle integration
         let oracle_multiplier = Self::fetch_oracle_multiplier(e, &config);
@@ -712,6 +682,57 @@ impl SoulboundTicketContract {
 
         // We only return the price here. It is updated during `purchase`.
         price
+    }
+
+    /// Demand-based standard pricing: price increases by `PRICE_INCREASE_BPS` per threshold passed.
+    fn apply_standard_pricing(base_price: i128, tier: &Tier) -> i128 {
+        let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
+        let multiplier = (thresholds_passed as i128)
+            .checked_mul(PRICE_INCREASE_BPS)
+            .expect("Arithmetic overflow");
+        let increase = base_price
+            .checked_mul(multiplier)
+            .and_then(|v| v.checked_div(BPS_PRECISION))
+            .expect("Arithmetic overflow");
+        base_price.checked_add(increase).expect("Arithmetic overflow")
+    }
+
+    /// Time-decay pricing: applies an early-bird discount if purchased before the event week.
+    fn apply_time_decay_pricing(e: &Env, base_price: i128, _tier: &Tier) -> i128 {
+        let event_info: EventInfo = e.storage().instance().get(&DataKey::EventInfo).unwrap();
+        let now = e.ledger().timestamp();
+        let start = event_info.start_time.saturating_sub(ONE_WEEK_SECONDS);
+        if now < start {
+            let discount = base_price
+                .checked_mul(EARLY_BIRD_DISCOUNT_BPS)
+                .and_then(|v| v.checked_div(BPS_PRECISION))
+                .expect("Arithmetic overflow");
+            base_price.checked_sub(discount).expect("Arithmetic overflow")
+        } else {
+            base_price
+        }
+    }
+
+    /// A/B test variant A: double demand sensitivity (10% increase per threshold).
+    fn apply_ab_test_a_pricing(base_price: i128, tier: &Tier) -> i128 {
+        let thresholds_passed = tier.minted / (tier.max_supply.max(1) / 5).max(1);
+        let multiplier = (thresholds_passed as i128)
+            .checked_mul(PRICE_INCREASE_BPS * 2)
+            .expect("Arithmetic overflow");
+        let increase = base_price
+            .checked_mul(multiplier)
+            .and_then(|v| v.checked_div(BPS_PRECISION))
+            .expect("Arithmetic overflow");
+        base_price.checked_add(increase).expect("Arithmetic overflow")
+    }
+
+    /// A/B test variant B: floor starts 20% higher than base price.
+    fn apply_ab_test_b_pricing(base_price: i128) -> i128 {
+        let uplift = base_price
+            .checked_mul(AB_TEST_B_FLOOR_UPLIFT_BPS)
+            .and_then(|v| v.checked_div(BPS_PRECISION))
+            .expect("Arithmetic overflow");
+        base_price.checked_add(uplift).expect("Arithmetic overflow")
     }
 
     // Batch Minting for Organizer
@@ -733,29 +754,8 @@ impl SoulboundTicketContract {
         }
 
         for _ in 0..amount {
-            // custom sequential increment
-            let mut counter: u32 = e
-                .storage()
-                .instance()
-                .get(&DataKey::TokenIdCounter)
-                .unwrap();
-            counter = counter.checked_add(1).expect("Counter overflow");
-            let token_id = counter;
-            e.storage()
-                .instance()
-                .set(&DataKey::TokenIdCounter, &counter);
-
-            Base::sequential_mint(e, &to);
-
-            let ticket = Ticket {
-                tier_symbol: tier_symbol.clone(),
-                purchase_time: e.ledger().timestamp(),
-                price_paid: 0, // Admin mints are free
-                is_valid: true,
-            };
-            e.storage()
-                .persistent()
-                .set(&DataKey::Ticket(token_id), &ticket);
+            let token_id = Self::mint_next_token(e, &to, &tier_symbol, 0);
+            let _ = token_id; // suppress unused warning; counter already updated
         }
 
         tier.minted = tier.minted.checked_add(amount).expect("Supply overflow");
@@ -793,29 +793,8 @@ impl SoulboundTicketContract {
         let token_client = token::Client::new(e, &payment_token);
         token_client.transfer(&buyer, &admin, &price);
 
-        // Mint Token
-        let mut counter: u32 = e
-            .storage()
-            .instance()
-            .get(&DataKey::TokenIdCounter)
-            .unwrap();
-        counter = counter.checked_add(1).expect("Counter overflow");
-        let token_id = counter;
-        e.storage()
-            .instance()
-            .set(&DataKey::TokenIdCounter, &counter);
-
-        Base::sequential_mint(e, &buyer);
-
-        let ticket = Ticket {
-            tier_symbol: tier_symbol.clone(),
-            purchase_time: e.ledger().timestamp(),
-            price_paid: price,
-            is_valid: true,
-        };
-        e.storage()
-            .persistent()
-            .set(&DataKey::Ticket(token_id), &ticket);
+        // Mint token and store ticket metadata
+        let token_id = Self::mint_next_token(e, &buyer, &tier_symbol, price);
 
         tier.minted = tier.minted.checked_add(1).expect("Supply overflow");
         tier.current_price = price; // Update the current recorded price for this tier
@@ -832,6 +811,31 @@ impl SoulboundTicketContract {
             (Symbol::new(&e, "ticket_purchased"), buyer),
             (tier_symbol, token_id, price),
         );
+    }
+
+    /// Increments the token ID counter, calls `Base::sequential_mint`, stores the ticket, and
+    /// returns the new token ID. `price_paid` should be 0 for admin/batch mints.
+    fn mint_next_token(e: &Env, to: &Address, tier_symbol: &Symbol, price_paid: i128) -> u32 {
+        let mut counter: u32 = e
+            .storage()
+            .instance()
+            .get(&DataKey::TokenIdCounter)
+            .unwrap();
+        counter = counter.checked_add(1).expect("Counter overflow");
+        let token_id = counter;
+        e.storage().instance().set(&DataKey::TokenIdCounter, &counter);
+
+        Base::sequential_mint(e, to);
+
+        let ticket = Ticket {
+            tier_symbol: tier_symbol.clone(),
+            purchase_time: e.ledger().timestamp(),
+            price_paid,
+            is_valid: true,
+        };
+        e.storage().persistent().set(&DataKey::Ticket(token_id), &ticket);
+
+        token_id
     }
 
     // Refund a ticket

--- a/contract/vrf_contract/src/lib.rs
+++ b/contract/vrf_contract/src/lib.rs
@@ -341,50 +341,61 @@ impl VRFContract {
 
     fn collect_entropy_sources(e: &Env) -> Vec<EntropySource> {
         let mut sources = Vec::new(e);
+        sources.push_back(Self::build_block_hash_entropy(e));
+        sources.push_back(Self::build_timestamp_entropy(e));
+        sources.push_back(Self::build_ledger_sequence_entropy(e));
+        sources.push_back(Self::build_network_entropy(e));
+        sources
+    }
 
-        // Block hash entropy
+    /// Builds an entropy source derived from the current ledger sequence (block hash proxy).
+    fn build_block_hash_entropy(e: &Env) -> EntropySource {
         let block_hash = e.crypto().sha256(&e.ledger().sequence().to_val().to_bytes());
-        sources.push_back(EntropySource {
+        EntropySource {
             source_type: SourceType::BlockHash,
             value: block_hash,
             weight: ENTROPY_WEIGHT_BLOCK_HASH,
             timestamp: e.ledger().timestamp(),
             reliability: 0.9,
-        });
+        }
+    }
 
-        // Timestamp entropy
+    /// Builds an entropy source derived from the current ledger timestamp.
+    fn build_timestamp_entropy(e: &Env) -> EntropySource {
         let timestamp_bytes = e.ledger().timestamp().to_be_bytes();
         let timestamp_hash = e.crypto().sha256(&timestamp_bytes.to_vec(e).to_bytes());
-        sources.push_back(EntropySource {
+        EntropySource {
             source_type: SourceType::Timestamp,
             value: timestamp_hash,
             weight: ENTROPY_WEIGHT_TIMESTAMP,
             timestamp: e.ledger().timestamp(),
             reliability: 0.8,
-        });
+        }
+    }
 
-        // Ledger sequence entropy
+    /// Builds an entropy source derived from the current ledger sequence number.
+    fn build_ledger_sequence_entropy(e: &Env) -> EntropySource {
         let sequence_bytes = e.ledger().sequence().to_be_bytes();
         let sequence_hash = e.crypto().sha256(&sequence_bytes.to_vec(e).to_bytes());
-        sources.push_back(EntropySource {
+        EntropySource {
             source_type: SourceType::LedgerSequence,
             value: sequence_hash,
             weight: ENTROPY_WEIGHT_LEDGER_SEQUENCE,
             timestamp: e.ledger().timestamp(),
             reliability: 0.9,
-        });
+        }
+    }
 
-        // Network entropy (simplified - in practice would use more sources)
+    /// Builds an entropy source derived from the contract's own address (network entropy proxy).
+    fn build_network_entropy(e: &Env) -> EntropySource {
         let network_entropy = e.crypto().sha256(&e.current_contract_address().to_val().to_bytes());
-        sources.push_back(EntropySource {
+        EntropySource {
             source_type: SourceType::NetworkEntropy,
             value: network_entropy,
             weight: ENTROPY_WEIGHT_LEDGER_SEQUENCE, // same weight as ledger sequence
             timestamp: e.ledger().timestamp(),
             reliability: 0.7,
-        });
-
-        sources
+        }
     }
 
     fn select_providers(e: &Env, max_providers: u32) -> Vec<Address> {
@@ -433,7 +444,7 @@ impl VRFContract {
         results
     }
 
-    fn monobit_test(randomness: &BytesN<32>) -> TestResult {
+    pub(crate) fn monobit_test(randomness: &BytesN<32>) -> TestResult {
         let mut ones = 0;
         for byte in randomness.as_bytes() {
             for bit in 0..8 {
@@ -460,7 +471,7 @@ impl VRFContract {
         }
     }
 
-    fn runs_test(randomness: &BytesN<32>) -> TestResult {
+    pub(crate) fn runs_test(randomness: &BytesN<32>) -> TestResult {
         let mut runs = 1;
         let mut prev_bit = randomness.as_bytes()[0] & 1;
 
@@ -490,7 +501,7 @@ impl VRFContract {
         }
     }
 
-    fn longest_run_test(randomness: &BytesN<32>) -> TestResult {
+    pub(crate) fn longest_run_test(randomness: &BytesN<32>) -> TestResult {
         let mut longest_run = 0;
         let mut current_run = 0;
         let mut prev_bit = 0;

--- a/contract/vrf_contract/src/test.rs
+++ b/contract/vrf_contract/src/test.rs
@@ -286,3 +286,67 @@ fn test_pause_unpause() {
     // Unpause contract
     VRFContract::unpause(env.clone());
 }
+
+// ─── Direct unit tests for the statistical quality helpers ──────────────────
+
+#[test]
+fn test_monobit_alternating_passes() {
+    // Alternating 10101010... = perfectly balanced bits -> monobit should pass.
+    let env = Env::default();
+    let data = [0xAA_u8; 32]; // 10101010 repeated
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::monobit_test(&randomness);
+    assert!(result.passed, "Alternating bits should pass monobit test");
+    assert!(result.score >= 0.0);
+}
+
+#[test]
+fn test_monobit_all_zeros_fails() {
+    // All zeros -> no ones at all -> should fail monobit.
+    let env = Env::default();
+    let data = [0x00_u8; 32];
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::monobit_test(&randomness);
+    assert!(!result.passed, "All-zero bits should fail monobit test");
+}
+
+#[test]
+fn test_runs_alternating_passes() {
+    // Alternating bits produce the expected number of runs -> should pass.
+    let env = Env::default();
+    let data = [0xAA_u8; 32];
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::runs_test(&randomness);
+    assert!(result.passed, "Alternating bits should pass runs test");
+}
+
+#[test]
+fn test_runs_all_ones_fails() {
+    // All ones -> exactly 1 run -> should fail runs test.
+    let env = Env::default();
+    let data = [0xFF_u8; 32];
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::runs_test(&randomness);
+    assert!(!result.passed, "All-ones bits should fail runs test");
+}
+
+#[test]
+fn test_longest_run_alternating_passes() {
+    // Alternating bits -> longest run of ones is 1 -> well within the 26-bit limit.
+    let env = Env::default();
+    let data = [0xAA_u8; 32];
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::longest_run_test(&randomness);
+    assert!(result.passed, "Alternating bits should pass longest-run test");
+    assert_eq!(result.score, 1.0);
+}
+
+#[test]
+fn test_longest_run_all_ones_fails() {
+    // All ones -> longest run of 256 bits -> far exceeds limit.
+    let env = Env::default();
+    let data = [0xFF_u8; 32];
+    let randomness = BytesN::from_array(&env, &data);
+    let result = VRFContract::longest_run_test(&randomness);
+    assert!(!result.passed, "All-ones bits should fail longest-run test");
+}

--- a/contract/zk_ticket_contract/src/lib.rs
+++ b/contract/zk_ticket_contract/src/lib.rs
@@ -180,32 +180,14 @@ impl ZKTicketContract {
             panic!("contract is paused");
         }
 
-        let commitment: TicketCommitment = env.storage().instance().get(&DataKey::TicketCommitment(ticket_commitment.clone()))
-            .unwrap_or_else(|| panic!("commitment not found"));
-
-        if !commitment.active {
-            panic!("commitment inactive");
-        }
-
-        if commitment.event_id != event_id {
-            panic!("event mismatch");
-        }
-
-        let nullifier_info: NullifierInfo = env.storage().instance().get(&DataKey::Nullifier(nullifier.clone()))
-            .unwrap_or_else(|| panic!("nullifier not found"));
-
-        if nullifier_info.used {
-            panic!("nullifier already used");
-        }
-
-        if env.ledger().timestamp() > expires_at {
-            panic!("proof expired");
-        }
-
-        let revocation_list: RevocationList = env.storage().instance().get(&DataKey::RevocationList).unwrap();
-        if revocation_list.revoked_commitments.contains(&ticket_commitment) {
-            panic!("ticket revoked");
-        }
+        // Validate all proof preconditions (commitment active, nullifier unused, not expired, not revoked)
+        let (commitment, _nullifier_info) = Self::validate_proof_state(
+            &env,
+            &ticket_commitment,
+            &nullifier,
+            &event_id,
+            expires_at,
+        )?;
 
         let verification_hash = Self::verify_zk_proof(&env, &proof_data, &attributes, &commitment)?;
         
@@ -227,7 +209,7 @@ impl ZKTicketContract {
 
         env.storage().instance().set(&DataKey::ZKProof(proof_id.clone()), &zk_proof);
 
-        let mut updated_nullifier = nullifier_info;
+        let mut updated_nullifier = _nullifier_info;
         updated_nullifier.used = true;
         updated_nullifier.used_at = Some(env.ledger().timestamp());
         updated_nullifier.proof_id = Some(proof_id.clone());
@@ -496,7 +478,53 @@ impl ZKTicketContract {
         // In a real implementation, you'd validate the circuit hashes against known good circuits
     }
 
-    fn validate_attributes(e: &Env, attributes: &Vec<ZKAttribute>) -> Result<(), ZKTicketError> {
+    /// Validates that a proof submission is allowed by checking commitment state, nullifier,
+    /// expiry, and revocation. Returns `(commitment, nullifier_info)` on success.
+    fn validate_proof_state(
+        env: &Env,
+        ticket_commitment: &BytesN<32>,
+        nullifier: &BytesN<32>,
+        event_id: &Address,
+        expires_at: u64,
+    ) -> Result<(TicketCommitment, NullifierInfo), ZKTicketError> {
+        let commitment: TicketCommitment = env
+            .storage()
+            .instance()
+            .get(&DataKey::TicketCommitment(ticket_commitment.clone()))
+            .unwrap_or_else(|| panic!("commitment not found"));
+
+        if !commitment.active {
+            panic!("commitment inactive");
+        }
+
+        if commitment.event_id != *event_id {
+            panic!("event mismatch");
+        }
+
+        let nullifier_info: NullifierInfo = env
+            .storage()
+            .instance()
+            .get(&DataKey::Nullifier(nullifier.clone()))
+            .unwrap_or_else(|| panic!("nullifier not found"));
+
+        if nullifier_info.used {
+            panic!("nullifier already used");
+        }
+
+        if env.ledger().timestamp() > expires_at {
+            panic!("proof expired");
+        }
+
+        let revocation_list: RevocationList =
+            env.storage().instance().get(&DataKey::RevocationList).unwrap();
+        if revocation_list.revoked_commitments.contains(ticket_commitment) {
+            panic!("ticket revoked");
+        }
+
+        Ok((commitment, nullifier_info))
+    }
+
+    pub(crate) fn validate_attributes(e: &Env, attributes: &Vec<ZKAttribute>) -> Result<(), ZKTicketError> {
         if attributes.is_empty() {
             return Err(ZKTicketError::InsufficientAttributes);
         }

--- a/contract/zk_ticket_contract/src/test.rs
+++ b/contract/zk_ticket_contract/src/test.rs
@@ -1,5 +1,5 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
-use crate::{ZKTicketContract, ZKAttribute, AttributeType, CircuitParameters, BatchStatus};
+use crate::{ZKTicketContract, ZKAttribute, AttributeType, ZKTicketError, CircuitParameters, BatchStatus};
 
 #[test]
 fn test_initialize() {
@@ -578,4 +578,69 @@ fn test_proof_expiration() {
         );
     });
     assert!(result.is_err());
+}
+
+// ─── Direct unit tests for extracted helpers ────────────────────────────────────────
+
+fn make_attrs(env: &Env) -> Vec<ZKAttribute> {
+    let mut attrs = Vec::new(env);
+    attrs.push_back(ZKAttribute {
+        attribute_type: AttributeType::TicketId,
+        value: Vec::from_array(env, [1u8; 32]),
+        commitment: BytesN::from_array(env, &[1; 32]),
+        revealed: false,
+    });
+    attrs.push_back(ZKAttribute {
+        attribute_type: AttributeType::EventId,
+        value: Vec::from_array(env, [2u8; 32]),
+        commitment: BytesN::from_array(env, &[2; 32]),
+        revealed: false,
+    });
+    attrs
+}
+
+#[test]
+fn test_validate_attributes_passes_with_required() {
+    let env = Env::default();
+    let attrs = make_attrs(&env);
+    let result = ZKTicketContract::validate_attributes(&env, &attrs);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_validate_attributes_fails_when_empty() {
+    let env = Env::default();
+    let attrs: Vec<ZKAttribute> = Vec::new(&env);
+    let result = ZKTicketContract::validate_attributes(&env, &attrs);
+    assert_eq!(result, Err(ZKTicketError::InsufficientAttributes));
+}
+
+#[test]
+fn test_validate_attributes_fails_missing_ticket_id() {
+    let env = Env::default();
+    let mut attrs = Vec::new(&env);
+    // Only EventId, missing TicketId
+    attrs.push_back(ZKAttribute {
+        attribute_type: AttributeType::EventId,
+        value: Vec::from_array(&env, [2u8; 32]),
+        commitment: BytesN::from_array(&env, &[2; 32]),
+        revealed: false,
+    });
+    let result = ZKTicketContract::validate_attributes(&env, &attrs);
+    assert_eq!(result, Err(ZKTicketError::InsufficientAttributes));
+}
+
+#[test]
+fn test_validate_attributes_fails_missing_event_id() {
+    let env = Env::default();
+    let mut attrs = Vec::new(&env);
+    // Only TicketId, missing EventId
+    attrs.push_back(ZKAttribute {
+        attribute_type: AttributeType::TicketId,
+        value: Vec::from_array(&env, [1u8; 32]),
+        commitment: BytesN::from_array(&env, &[1; 32]),
+        revealed: false,
+    });
+    let result = ZKTicketContract::validate_attributes(&env, &attrs);
+    assert_eq!(result, Err(ZKTicketError::InsufficientAttributes));
 }


### PR DESCRIPTION
- governance: extract cast_single_vote() and evaluate_proposal_outcome() helpers; vote() 78->35 lines, queue() 45->25 lines; add 3 new tests
- vrf: extract 4 entropy source builder helpers from collect_entropy_sources(); make monobit_test/runs_test/longest_run_test pub(crate); add 6 direct unit tests
- subscription: extract build_user_subscription() shared by subscribe()+claim_gift(); add 4 lifecycle tests
- dutch_auction: fix e->env identifier bugs and ? operator misuse; extract validate_bid_amount() and apply_auction_extension() helpers; add 3 price tests
- escrow: extract pub(crate) compute_revenue_splits() deduplicating both distribute_revenue functions; fix Cargo.toml strip value; add 3 split tests
- zk_ticket: extract validate_proof_state() guard (7 checks) from submit_proof(); submit_proof() 83->40 lines; make validate_attributes() pub(crate); add 4 tests
- ticket: extract 4 pricing strategy helpers from get_ticket_price(); extract mint_next_token() shared by batch_mint() and purchase()
- 

Closes #290  