### PR TITLE
feat: Implement comprehensive property-based testing with fast-check

### DIFF
--- a/app/backend/PROPERTY_BASED_TESTING.md
+++ b/app/backend/PROPERTY_BASED_TESTING.md
@@ -1,0 +1,277 @@
+# Property-Based Testing Implementation
+
+This document outlines the comprehensive property-based testing implementation for the Gatherraa project, addressing issue #318 "Missing Property-Based Tests".
+
+## Overview
+
+Property-based testing complements traditional example-based testing by generating a wide range of inputs and verifying that certain properties (invariants) always hold true. This implementation uses the `fast-check` library to provide robust, automated testing that can uncover edge cases and bugs that traditional testing might miss.
+
+## Implementation Components
+
+### 1. Test Utilities and Generators (`test/utils/property-test-utils.ts`)
+
+#### ArbitraryGenerators
+Provides reusable data generators for creating test data:
+
+- **user()**: Generates valid User entities with all required fields
+- **organizerUser()**: Generates users with ORGANIZER role
+- **adminUser()**: Generates users with ADMIN role
+- **regularUser()**: Generates users with USER role
+- **event()**: Generates valid Event entities
+- **createUserDto()**: Generates CreateUserDto objects
+- **updateUserDto()**: Generates UpdateUserDto objects
+- **walletAddress()**: Generates valid Ethereum wallet addresses
+- **nonce()**: Generates cryptographic nonces
+- **paginationParams()**: Generates pagination parameters
+
+#### PropertyTestHelpers
+Provides assertion helpers for verifying invariants:
+
+- **assertUserInvariants()**: Validates user entity structure and constraints
+- **assertEventInvariants()**: Validates event entity structure and constraints
+- **assertTokenInvariants()**: Validates JWT token structure
+- **assertPaginationInvariants()**: Validates pagination parameters
+- **assertDateOrderInvariants()**: Validates date relationships
+- **assertWalletAddressInvariants()**: Validates wallet address format
+- **assertEmailInvariants()**: Validates email format
+
+#### FuzzTestHelpers
+Provides malicious and edge case inputs for fuzz testing:
+
+- **generateMaliciousStrings()**: XSS, SQL injection, path traversal attempts
+- **generateEdgeCaseNumbers()**: Boundary values and special numbers
+- **generateEdgeCaseDates()**: Extreme date values
+- **generateInvalidWalletAddresses()**: Malformed wallet addresses
+- **generateInvalidEmails()**: Malformed email addresses
+
+### 2. Service-Specific Property Tests
+
+#### EventsService Tests (`test/events.service.property.spec.ts`)
+Tests critical event management functions:
+
+- **Event Creation**: Validates invariants for event creation with valid data
+- **Duplicate Prevention**: Ensures contract address uniqueness
+- **Authorization**: Verifies role-based access control
+- **Event Retrieval**: Tests pagination and search functionality
+- **Event Updates**: Validates update operations and date consistency
+- **Contract Address Lookup**: Tests wallet address-based searches
+
+#### AuthService Tests (`test/auth.service.property.spec.ts`)
+Tests authentication and authorization functions:
+
+- **Nonce Generation**: Validates cryptographic nonce generation
+- **Token Generation**: Tests JWT token creation and structure
+- **Token Validation**: Verifies token validation and user lookup
+- **Token Refresh**: Tests refresh token functionality
+- **SIWE Verification**: Validates Sign-In with Ethereum messages
+- **Security**: Tests handling of malicious inputs
+
+#### UserService Tests (`test/users.service.property.spec.ts`)
+Tests user management functions:
+
+- **User Creation**: Validates user creation with various inputs
+- **User Retrieval**: Tests user lookup and privacy controls
+- **User Updates**: Validates user profile updates
+- **Search Functionality**: Tests user search with various queries
+- **Wallet Authentication**: Tests nonce generation and validation
+- **User Creation from Wallet**: Tests wallet-based user registration
+
+### 3. Invariant Testing (`test/invariants.consistency.spec.ts`)
+
+Tests data consistency and cross-service invariants:
+
+- **Event-User Relationships**: Ensures organizer relationships are maintained
+- **User Role Hierarchies**: Validates role-based permissions
+- **Temporal Consistency**: Ensures date/time relationships are valid
+- **Token Payload Consistency**: Validates JWT token structure
+- **Profile Completion**: Ensures completion percentages are valid
+- **Cross-Service Consistency**: Validates data consistency across services
+
+### 4. Fuzz Testing (`test/fuzz.input-validation.spec.ts`)
+
+Tests system resilience against malicious and extreme inputs:
+
+- **Malicious String Inputs**: XSS, injection attempts, special characters
+- **Extreme Values**: Very long strings, edge case numbers, extreme dates
+- **Invalid Formats**: Malformed addresses, emails, UUIDs
+- **Boundary Conditions**: Pagination limits, string length boundaries
+- **Encoding Issues**: Unicode, special characters, HTML/JS injection
+- **Resource Exhaustion**: Memory pressure, rapid requests
+
+## Usage Examples
+
+### Running Property-Based Tests
+
+```bash
+# Run all property-based tests
+npm test -- --testPathPattern=".*\\.property\\.spec\\.ts$"
+
+# Run specific property test file
+npm test test/events.service.property.spec.ts
+
+# Run with coverage
+npm run test:cov -- --testPathPattern=".*\\.property\\.spec\\.ts$"
+
+# Run fuzz tests
+npm test test/fuzz.input-validation.spec.ts
+
+# Run invariant tests
+npm test test/invariants.consistency.spec.ts
+```
+
+### Writing New Property Tests
+
+```typescript
+import { fc, test } from 'fast-check';
+import { ArbitraryGenerators, PropertyTestHelpers } from './utils/property-test-utils';
+
+describe('MyService Property Tests', () => {
+  it('should maintain invariants for all valid inputs', async () => {
+    await test(
+      fc.asyncProperty(
+        ArbitraryGenerators.user(),
+        ArbitraryGenerators.event(),
+        async (user, event) => {
+          // Arrange
+          jest.spyOn(repository, 'save').mockResolvedValue(event);
+          
+          // Act
+          const result = await service.createEvent(event, user);
+          
+          // Assert invariants
+          PropertyTestHelpers.assertEventInvariants(result);
+          expect(result.organizerId).toBe(user.id);
+        }
+      ),
+      { numRuns: 100 } // Number of test cases to generate
+    );
+  });
+});
+```
+
+## Configuration
+
+### Jest Configuration Updates
+
+The Jest configuration has been updated to support property-based testing:
+
+```json
+{
+  "jest": {
+    "testRegex": ".*\\.spec\\.ts$",
+    "transform": {
+      "^.+\\.(t|j)s$": "ts-jest"
+    },
+    "collectCoverageFrom": [
+      "**/*.(t|j)s"
+    ],
+    "coverageDirectory": "../coverage",
+    "testEnvironment": "node",
+    "setupFilesAfterEnv": ["<rootDir>/test/setup.ts"]
+  }
+}
+```
+
+### Test Run Configuration
+
+Property-based tests use different run configurations:
+
+- **numRuns**: Number of test cases to generate (typically 50-100)
+- **timeout**: Extended timeout for complex operations (30-60 seconds)
+- **seed**: Optional seed for reproducible test failures
+
+## Benefits
+
+### 1. **Increased Test Coverage**
+- Tests hundreds of input combinations automatically
+- Covers edge cases that manual testing might miss
+- Validates invariants across all input ranges
+
+### 2. **Bug Detection**
+- Uncovers subtle bugs in data validation
+- Finds issues with boundary conditions
+- Detects problems with data relationships
+
+### 3. **Regression Prevention**
+- Catches breaking changes in data contracts
+- Validates that invariants are maintained
+- Ensures refactoring doesn't introduce bugs
+
+### 4. **Documentation**
+- Tests serve as living documentation of expected behavior
+- Invariants clearly define system constraints
+- Property tests explain system behavior through examples
+
+## Best Practices
+
+### 1. **Define Clear Invariants**
+- Focus on properties that should always be true
+- Test business rules and data constraints
+- Validate security properties
+
+### 2. **Use Appropriate Generators**
+- Create realistic test data
+- Cover edge cases and boundary conditions
+- Include both valid and invalid inputs
+
+### 3. **Test Error Handling**
+- Verify graceful failure modes
+- Test error message consistency
+- Ensure no crashes on invalid input
+
+### 4. **Performance Considerations**
+- Limit test runs for expensive operations
+- Use appropriate timeouts
+- Mock external dependencies
+
+### 5. **Maintainability**
+- Keep tests focused and readable
+- Use helper functions for common operations
+- Document complex invariants
+
+## Integration with CI/CD
+
+Property-based tests are integrated into the CI pipeline:
+
+```yaml
+# .github/workflows/test.yml
+- name: Run Property-Based Tests
+  run: |
+    npm run test:property
+    npm run test:fuzz
+    npm run test:invariants
+```
+
+## Future Enhancements
+
+### 1. **Additional Services**
+- Add property tests for remaining services
+- Test payment processing workflows
+- Validate notification system invariants
+
+### 2. **Advanced Generators**
+- Create more sophisticated data generators
+- Add domain-specific generators
+- Implement custom shrinkers
+
+### 3. **Performance Testing**
+- Add performance property tests
+- Test scalability invariants
+- Validate resource usage constraints
+
+### 4. **Security Testing**
+- Expand security fuzz testing
+- Add cryptographic property tests
+- Test authentication invariants
+
+## Conclusion
+
+This property-based testing implementation significantly improves the reliability and robustness of the Gatherraa application by:
+
+1. **Automating** the generation of comprehensive test cases
+2. **Validating** critical invariants across all services
+3. **Preventing** regressions through automated testing
+4. **Documenting** system behavior through tests
+5. **Improving** overall code quality and reliability
+
+The implementation follows best practices for property-based testing and provides a solid foundation for continued testing improvements.

--- a/app/backend/package.json
+++ b/app/backend/package.json
@@ -18,6 +18,9 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:property": "jest --testPathPattern=\".*\\.property\\.spec\\.ts$\" --testTimeout=30000",
+    "test:fuzz": "jest --testPathPattern=\".*\\.fuzz\\.spec\\.ts$\" --testTimeout=60000",
+    "test:invariants": "jest --testPathPattern=\".*\\.invariants\\.spec\\.ts$\" --testTimeout=30000",
     "migration:run": "ts-node -r tsconfig-paths/register ./src/migrations/runner.ts run",
     "migration:revert": "ts-node -r tsconfig-paths/register ./src/migrations/runner.ts revert",
     "migration:dry-run": "ts-node -r tsconfig-paths/register ./src/migrations/runner.ts dry-run",
@@ -111,6 +114,7 @@
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
+    "fast-check": "^3.15.0",
     "globals": "^16.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
@@ -138,6 +142,8 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "testTimeout": 10000,
+    "setupFilesAfterEnv": ["<rootDir>/test/setup.ts"]
   }
 }

--- a/app/backend/test/auth.service.property.spec.ts
+++ b/app/backend/test/auth.service.property.spec.ts
@@ -1,0 +1,532 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { fc, test } from 'fast-check';
+import { AuthService, TokenPayload, AuthTokens } from '../src/auth/auth.service';
+import { UsersService } from '../src/users/users.service';
+import { SessionsService } from '../src/sessions/sessions.service';
+import { User, UserRole } from '../src/users/entities/user.entity';
+import { ArbitraryGenerators, PropertyTestHelpers, FuzzTestHelpers } from './utils/property-test-utils';
+
+describe('AuthService Property-Based Tests', () => {
+  let service: AuthService;
+  let usersService: UsersService;
+  let sessionsService: SessionsService;
+  let jwtService: JwtService;
+  let configService: ConfigService;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: UsersService,
+          useValue: {
+            generateNonce: jest.fn(),
+            validateNonce: jest.fn(),
+            findOneByWallet: jest.fn(),
+            findOneById: jest.fn(),
+            createFromWallet: jest.fn(),
+          },
+        },
+        {
+          provide: SessionsService,
+          useValue: {
+            createSession: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn(),
+            verify: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+    usersService = module.get<UsersService>(UsersService);
+    sessionsService = module.get<SessionsService>(SessionsService);
+    jwtService = module.get<JwtService>(JwtService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('Nonce Generation Property Tests', () => {
+    it('should generate valid nonces for wallet addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          ArbitraryGenerators.nonce(),
+          async (walletAddress, nonce) => {
+            // Arrange
+            jest.spyOn(usersService, 'generateNonce').mockResolvedValue(nonce);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            const result = await service.generateNonce(walletAddress);
+
+            // Assert
+            expect(result).toHaveProperty('nonce');
+            expect(typeof result.nonce).toBe('string');
+            expect(result.nonce.length).toBeGreaterThan(0);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should handle invalid wallet addresses gracefully', async () => {
+      const invalidAddresses = FuzzTestHelpers.generateInvalidWalletAddresses();
+      
+      for (const invalidAddress of invalidAddresses) {
+        // Should either succeed or fail gracefully
+        try {
+          jest.spyOn(usersService, 'generateNonce').mockResolvedValue('valid-nonce');
+          const result = await service.generateNonce(invalidAddress as string);
+          expect(result).toHaveProperty('nonce');
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Token Generation Property Tests', () => {
+    it('should generate valid tokens for any user', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          ArbitraryGenerators.walletAddress(),
+          async (user, sessionId) => {
+            // Arrange
+            const mockAccessToken = 'access-token-' + Math.random();
+            const mockRefreshToken = 'refresh-token-' + Math.random();
+            
+            jest.spyOn(jwtService, 'sign')
+              .mockReturnValueOnce(mockAccessToken)
+              .mockReturnValueOnce(mockRefreshToken);
+            jest.spyOn(sessionsService, 'createSession').mockResolvedValue(undefined);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            const result = await service.generateTokens(user);
+
+            // Assert
+            expect(result).toHaveProperty('accessToken');
+            expect(result).toHaveProperty('refreshToken');
+            expect(typeof result.accessToken).toBe('string');
+            expect(typeof result.refreshToken).toBe('string');
+            expect(result.accessToken.length).toBeGreaterThan(0);
+            expect(result.refreshToken.length).toBeGreaterThan(0);
+            expect(result.accessToken).toBe(mockAccessToken);
+            expect(result.refreshToken).toBe(mockRefreshToken);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should maintain token payload invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            const mockAccessToken = 'access-token-' + Math.random();
+            const mockRefreshToken = 'refresh-token-' + Math.random();
+            
+            jest.spyOn(jwtService, 'sign')
+              .mockReturnValueOnce(mockAccessToken)
+              .mockReturnValueOnce(mockRefreshToken);
+            jest.spyOn(sessionsService, 'createSession').mockResolvedValue(undefined);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            await service.generateTokens(user);
+
+            // Assert
+            expect(jwtService.sign).toHaveBeenCalledWith(
+              {
+                sub: user.id,
+                wallet: user.walletAddress,
+                roles: user.roles,
+              },
+              expect.objectContaining({
+                secret: 'test-secret',
+                expiresIn: '15m',
+              })
+            );
+
+            expect(jwtService.sign).toHaveBeenCalledWith(
+              { sub: user.id },
+              expect.objectContaining({
+                secret: 'test-secret',
+                expiresIn: '7d',
+              })
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Token Validation Property Tests', () => {
+    it('should validate tokens for active users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          fc.string(),
+          async (user, token) => {
+            // Arrange
+            const payload: TokenPayload = {
+              sub: user.id,
+              wallet: user.walletAddress,
+              roles: user.roles,
+            };
+
+            jest.spyOn(jwtService, 'verify').mockReturnValue(payload);
+            jest.spyOn(usersService, 'findOneById').mockResolvedValue(user);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            const result = await service.validateToken(token);
+
+            // Assert
+            PropertyTestHelpers.assertUserInvariants(result);
+            expect(result.id).toBe(user.id);
+            expect(result.walletAddress).toBe(user.walletAddress);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should reject tokens for inactive users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user().map(user => ({ ...user, isActive: false })),
+          fc.string(),
+          async (inactiveUser, token) => {
+            // Arrange
+            const payload: TokenPayload = {
+              sub: inactiveUser.id,
+              wallet: inactiveUser.walletAddress,
+              roles: inactiveUser.roles,
+            };
+
+            jest.spyOn(jwtService, 'verify').mockReturnValue(payload);
+            jest.spyOn(usersService, 'findOneById').mockResolvedValue(inactiveUser);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act & Assert
+            await expect(service.validateToken(token)).rejects.toThrow(
+              'User not found or inactive'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should reject invalid tokens', async () => {
+      await test(
+        fc.asyncProperty(
+          fc.string(),
+          async (invalidToken) => {
+            // Arrange
+            jest.spyOn(jwtService, 'verify').mockImplementation(() => {
+              throw new Error('Invalid token');
+            });
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act & Assert
+            await expect(service.validateToken(invalidToken)).rejects.toThrow(
+              'Invalid token'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Token Refresh Property Tests', () => {
+    it('should refresh tokens for active users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          fc.string(),
+          async (user, refreshToken) => {
+            // Arrange
+            const mockAccessToken = 'new-access-token-' + Math.random();
+            const mockNewRefreshToken = 'new-refresh-token-' + Math.random();
+            
+            jest.spyOn(jwtService, 'verify').mockReturnValue({ sub: user.id });
+            jest.spyOn(usersService, 'findOneById').mockResolvedValue(user);
+            jest.spyOn(jwtService, 'sign')
+              .mockReturnValueOnce(mockAccessToken)
+              .mockReturnValueOnce(mockNewRefreshToken);
+            jest.spyOn(sessionsService, 'createSession').mockResolvedValue(undefined);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            const result = await service.refreshTokens(refreshToken);
+
+            // Assert
+            expect(result).toHaveProperty('accessToken');
+            expect(result).toHaveProperty('refreshToken');
+            expect(typeof result.accessToken).toBe('string');
+            expect(typeof result.refreshToken).toBe('string');
+            expect(result.accessToken.length).toBeGreaterThan(0);
+            expect(result.refreshToken.length).toBeGreaterThan(0);
+            expect(result.accessToken).toBe(mockAccessToken);
+            expect(result.refreshToken).toBe(mockNewRefreshToken);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should reject refresh tokens for inactive users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user().map(user => ({ ...user, isActive: false })),
+          fc.string(),
+          async (inactiveUser, refreshToken) => {
+            // Arrange
+            jest.spyOn(jwtService, 'verify').mockReturnValue({ sub: inactiveUser.id });
+            jest.spyOn(usersService, 'findOneById').mockResolvedValue(inactiveUser);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act & Assert
+            await expect(service.refreshTokens(refreshToken)).rejects.toThrow(
+              'User not found or inactive'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('SIWE Message Verification Property Tests', () => {
+    it('should handle valid SIWE messages', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          ArbitraryGenerators.nonce(),
+          ArbitraryGenerators.user(),
+          async (walletAddress, nonce, user) => {
+            // Arrange
+            const mockSiweMessage = {
+              verify: jest.fn().mockResolvedValue({ success: true }),
+              address: walletAddress,
+              nonce: nonce,
+              domain: 'example.com',
+              uri: 'https://example.com',
+            };
+
+            const SiweMessageMock = jest.fn().mockImplementation(() => mockSiweMessage);
+            
+            jest.spyOn(usersService, 'validateNonce').mockResolvedValue(true);
+            jest.spyOn(usersService, 'findOneByWallet').mockResolvedValue(user);
+            jest.spyOn(configService, 'get')
+              .mockReturnValueOnce('example.com')
+              .mockReturnValueOnce('https://example.com');
+
+            // Temporarily replace SiweMessage import
+            const originalSiweMessage = require('siwe').SiweMessage;
+            require('siwe').SiweMessage = SiweMessageMock;
+
+            try {
+              // Act
+              const result = await service.verifySiweMessage('message', 'signature');
+
+              // Assert
+              PropertyTestHelpers.assertUserInvariants(result);
+              expect(result.walletAddress).toBe(walletAddress);
+            } finally {
+              // Restore original
+              require('siwe').SiweMessage = originalSiweMessage;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should create new users if they do not exist', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          ArbitraryGenerators.nonce(),
+          async (walletAddress, nonce) => {
+            // Arrange
+            const newUser = PropertyTestHelpers.createMockUser({ walletAddress });
+            const mockSiweMessage = {
+              verify: jest.fn().mockResolvedValue({ success: true }),
+              address: walletAddress,
+              nonce: nonce,
+              domain: 'example.com',
+              uri: 'https://example.com',
+            };
+
+            const SiweMessageMock = jest.fn().mockImplementation(() => mockSiweMessage);
+            
+            jest.spyOn(usersService, 'validateNonce').mockResolvedValue(true);
+            jest.spyOn(usersService, 'findOneByWallet').mockResolvedValue(null);
+            jest.spyOn(usersService, 'createFromWallet').mockResolvedValue(newUser);
+            jest.spyOn(configService, 'get')
+              .mockReturnValueOnce('example.com')
+              .mockReturnValueOnce('https://example.com');
+
+            // Temporarily replace SiweMessage import
+            const originalSiweMessage = require('siwe').SiweMessage;
+            require('siwe').SiweMessage = SiweMessageMock;
+
+            try {
+              // Act
+              const result = await service.verifySiweMessage('message', 'signature');
+
+              // Assert
+              PropertyTestHelpers.assertUserInvariants(result);
+              expect(usersService.createFromWallet).toHaveBeenCalledWith(walletAddress);
+            } finally {
+              // Restore original
+              require('siwe').SiweMessage = originalSiweMessage;
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Fuzz Tests for Authentication Security', () => {
+    it('should handle malformed tokens gracefully', async () => {
+      const malformedTokens = [
+        '',
+        'invalid.token',
+        'too.many.parts.in.token',
+        '🔥💣🚀',
+        '\x00\x01\x02',
+        'a'.repeat(10000),
+        ...FuzzTestHelpers.generateMaliciousStrings(),
+      ];
+
+      for (const token of malformedTokens) {
+        try {
+          jest.spyOn(jwtService, 'verify').mockImplementation(() => {
+            throw new Error('Invalid token');
+          });
+          jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+          await service.validateToken(token);
+          // If it doesn't throw, that's okay - it should handle gracefully
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle extreme wallet address inputs', async () => {
+      const extremeInputs = [
+        ...FuzzTestHelpers.generateInvalidWalletAddresses(),
+        '0x' + 'a'.repeat(1000), // Very long address
+        '0x' + '0'.repeat(40), // All zeros
+        '0x' + 'f'.repeat(40), // All f's
+      ];
+
+      for (const walletAddress of extremeInputs) {
+        try {
+          jest.spyOn(usersService, 'generateNonce').mockResolvedValue('nonce');
+          const result = await service.generateNonce(walletAddress as string);
+          expect(result).toHaveProperty('nonce');
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Invariant Tests', () => {
+    it('should maintain user role invariants across authentication', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          fc.string(),
+          async (user, token) => {
+            // Arrange
+            const payload: TokenPayload = {
+              sub: user.id,
+              wallet: user.walletAddress,
+              roles: user.roles,
+            };
+
+            jest.spyOn(jwtService, 'verify').mockReturnValue(payload);
+            jest.spyOn(usersService, 'findOneById').mockResolvedValue(user);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            const result = await service.validateToken(token);
+
+            // Assert
+            expect(result.roles).toEqual(user.roles);
+            expect(result.roles.length).toBeGreaterThan(0);
+            result.roles.forEach(role => {
+              expect(Object.values(UserRole)).toContain(role);
+            });
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain wallet address format invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            const mockAccessToken = 'access-token-' + Math.random();
+            const mockRefreshToken = 'refresh-token-' + Math.random();
+            
+            jest.spyOn(jwtService, 'sign')
+              .mockReturnValueOnce(mockAccessToken)
+              .mockReturnValueOnce(mockRefreshToken);
+            jest.spyOn(sessionsService, 'createSession').mockResolvedValue(undefined);
+            jest.spyOn(configService, 'get').mockReturnValue('test-secret');
+
+            // Act
+            await service.generateTokens(user);
+
+            // Assert
+            expect(jwtService.sign).toHaveBeenCalledWith(
+              expect.objectContaining({
+                wallet: user.walletAddress,
+              }),
+              expect.any(Object)
+            );
+
+            // Verify wallet address format is maintained
+            PropertyTestHelpers.assertWalletAddressInvariants(user.walletAddress);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+});

--- a/app/backend/test/events.service.property.spec.ts
+++ b/app/backend/test/events.service.property.spec.ts
@@ -1,0 +1,443 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import { Repository } from 'typeorm';
+import { fc, test } from 'fast-check';
+import { EventsService } from '../src/events/events.service';
+import { Event } from '../src/events/entities/event.entity';
+import { CreateEventDto } from '../src/events/dto/create-event.dto';
+import { UpdateEventDto } from '../src/events/dto/update-event.dto';
+import { User, UserRole } from '../src/users/entities/user.entity';
+import { ArbitraryGenerators, PropertyTestHelpers, FuzzTestHelpers } from './utils/property-test-utils';
+
+describe('EventsService Property-Based Tests', () => {
+  let service: EventsService;
+  let eventRepository: Repository<Event>;
+  let commandBus: CommandBus;
+  let queryBus: QueryBus;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            findAndCount: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: CommandBus,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+        {
+          provide: QueryBus,
+          useValue: {
+            execute: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<EventsService>(EventsService);
+    eventRepository = module.get<Repository<Event>>(getRepositoryToken(Event));
+    commandBus = module.get<CommandBus>(CommandBus);
+    queryBus = module.get<QueryBus>(QueryBus);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('Event Creation Property Tests', () => {
+    it('should maintain invariants when creating events with valid data', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.createEventDto(),
+          ArbitraryGenerators.organizerUser(),
+          async (createEventDto, user) => {
+            // Arrange
+            const mockEvent = PropertyTestHelpers.createMockEvent({
+              name: createEventDto.name,
+              description: createEventDto.description,
+              contractAddress: createEventDto.contractAddress,
+              organizerId: createEventDto.organizerId || user.id,
+              startTime: new Date(createEventDto.startTime),
+              endTime: createEventDto.endTime ? new Date(createEventDto.endTime) : undefined,
+            });
+
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+            jest.spyOn(eventRepository, 'create').mockReturnValue(mockEvent);
+            jest.spyOn(eventRepository, 'save').mockResolvedValue(mockEvent);
+
+            // Act
+            const result = await service.create(createEventDto, user);
+
+            // Assert
+            PropertyTestHelpers.assertEventInvariants(result);
+            expect(result.organizerId).toBe(createEventDto.organizerId || user.id);
+            expect(result.contractAddress).toBe(createEventDto.contractAddress);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should reject duplicate contract addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.createEventDto(),
+          ArbitraryGenerators.organizerUser(),
+          async (createEventDto, user) => {
+            // Arrange
+            const existingEvent = PropertyTestHelpers.createMockEvent({
+              contractAddress: createEventDto.contractAddress,
+            });
+
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(existingEvent);
+
+            // Act & Assert
+            await expect(service.create(createEventDto, user)).rejects.toThrow(
+              'Event with this contract address already exists'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should reject event creation by non-organizer users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.createEventDto(),
+          ArbitraryGenerators.regularUser(),
+          async (createEventDto, user) => {
+            // Act & Assert
+            await expect(service.create(createEventDto, user)).rejects.toThrow(
+              'Only organizers and admins can create events'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Event Retrieval Property Tests', () => {
+    it('should maintain pagination invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.paginationParams(),
+          fc.array(ArbitraryGenerators.event(), { minLength: 0, maxLength: 100 }),
+          async (pagination, events) => {
+            // Arrange
+            const skip = (pagination.page - 1) * pagination.limit;
+            const pagedEvents = events.slice(skip, skip + pagination.limit);
+            
+            jest.spyOn(eventRepository, 'findAndCount').mockResolvedValue([pagedEvents, events.length]);
+
+            // Act
+            const result = await service.findAll(pagination.page, pagination.limit);
+
+            // Assert
+            const [returnedEvents, totalCount] = result;
+            expect(returnedEvents.length).toBeLessThanOrEqual(pagination.limit);
+            expect(totalCount).toBe(events.length);
+            PropertyTestHelpers.assertPaginationInvariants(pagination.page, pagination.limit, totalCount);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should return valid event structure when found', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          async (event) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+
+            // Act
+            const result = await service.findOne(event.id);
+
+            // Assert
+            PropertyTestHelpers.assertEventInvariants(result);
+            expect(result.id).toBe(event.id);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should throw NotFoundException for non-existent events', async () => {
+      await test(
+        fc.asyncProperty(
+          fc.uuid(),
+          async (eventId) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.findOne(eventId)).rejects.toThrow(
+              `Event with ID ${eventId} not found`
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Event Update Property Tests', () => {
+    it('should maintain invariants when updating events', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.updateEventDto(),
+          ArbitraryGenerators.organizerUser(),
+          async (event, updateDto, user) => {
+            // Arrange
+            event.organizerId = user.id; // Ensure user is the organizer
+            const updatedEvent = { ...event, ...updateDto };
+
+            jest.spyOn(service, 'findOne').mockResolvedValue(event);
+            jest.spyOn(eventRepository, 'save').mockResolvedValue(updatedEvent);
+
+            // Act
+            const result = await service.update(event.id, updateDto, user);
+
+            // Assert
+            PropertyTestHelpers.assertEventInvariants(result);
+            if (updateDto.name) expect(result.name).toBe(updateDto.name);
+            if (updateDto.description !== undefined) expect(result.description).toBe(updateDto.description);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should reject updates by non-organizer users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.updateEventDto(),
+          ArbitraryGenerators.regularUser(),
+          async (event, updateDto, user) => {
+            // Arrange
+            jest.spyOn(service, 'findOne').mockResolvedValue(event);
+
+            // Act & Assert
+            await expect(service.update(event.id, updateDto, user)).rejects.toThrow(
+              'Only the event organizer or admin can update this event'
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain date order invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.validEventDates(),
+          ArbitraryGenerators.organizerUser(),
+          async (event, { startTime, endTime }, user) => {
+            // Arrange
+            event.organizerId = user.id;
+            const updateDto: UpdateEventDto = {
+              startTime: startTime.toISOString(),
+              endTime: endTime?.toISOString(),
+            };
+
+            const updatedEvent = { ...event, startTime, endTime };
+
+            jest.spyOn(service, 'findOne').mockResolvedValue(event);
+            jest.spyOn(eventRepository, 'save').mockResolvedValue(updatedEvent);
+
+            // Act
+            const result = await service.update(event.id, updateDto, user);
+
+            // Assert
+            PropertyTestHelpers.assertDateOrderInvariants(result.startTime, result.endTime || undefined);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+  });
+
+  describe('Contract Address Lookup Property Tests', () => {
+    it('should return null for non-existent contract addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          async (contractAddress) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+
+            // Act
+            const result = await service.findByContractAddress(contractAddress);
+
+            // Assert
+            expect(result).toBeNull();
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should return valid event for existing contract addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          async (event) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+
+            // Act
+            const result = await service.findByContractAddress(event.contractAddress);
+
+            // Assert
+            expect(result).not.toBeNull();
+            PropertyTestHelpers.assertEventInvariants(result!);
+            expect(result!.contractAddress).toBe(event.contractAddress);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Fuzz Tests for Input Validation', () => {
+    it('should handle malicious input gracefully in event names', async () => {
+      const maliciousInputs = FuzzTestHelpers.generateMaliciousStrings();
+      
+      for (const maliciousInput of maliciousInputs) {
+        const createEventDto: CreateEventDto = {
+          name: maliciousInput,
+          description: 'Valid description',
+          contractAddress: fc.sample(ArbitraryGenerators.walletAddress(), 1)[0],
+          organizerId: fc.sample(fc.uuid(), 1)[0],
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 3600000).toISOString(),
+        };
+
+        const user = PropertyTestHelpers.createMockUser({ roles: [UserRole.ORGANIZER] });
+
+        // Should either create successfully or fail gracefully with validation error
+        try {
+          jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+          jest.spyOn(eventRepository, 'create').mockReturnValue(PropertyTestHelpers.createMockEvent({ name: maliciousInput }));
+          jest.spyOn(eventRepository, 'save').mockResolvedValue(PropertyTestHelpers.createMockEvent({ name: maliciousInput }));
+          
+          const result = await service.create(createEventDto, user);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should be a validation error, not a crash
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle edge case wallet addresses', async () => {
+      const invalidAddresses = FuzzTestHelpers.generateInvalidWalletAddresses();
+      
+      for (const invalidAddress of invalidAddresses) {
+        const createEventDto: CreateEventDto = {
+          name: 'Valid Event Name',
+          description: 'Valid description',
+          contractAddress: invalidAddress as string,
+          organizerId: fc.sample(fc.uuid(), 1)[0],
+          startTime: new Date().toISOString(),
+          endTime: new Date(Date.now() + 3600000).toISOString(),
+        };
+
+        const user = PropertyTestHelpers.createMockUser({ roles: [UserRole.ORGANIZER] });
+
+        // Should fail gracefully with validation error
+        await expect(service.create(createEventDto, user)).rejects.toBeInstanceOf(Error);
+      }
+    });
+
+    it('should handle extreme pagination values', async () => {
+      const extremeValues = [
+        { page: 1, limit: 1 },
+        { page: 1000, limit: 1 },
+        { page: 1, limit: 100 },
+        { page: 500, limit: 100 },
+      ];
+
+      for (const pagination of extremeValues) {
+        jest.spyOn(eventRepository, 'findAndCount').mockResolvedValue([[], 0]);
+        
+        const result = await service.findAll(pagination.page, pagination.limit);
+        expect(result).toBeDefined();
+        expect(Array.isArray(result[0])).toBe(true);
+        expect(typeof result[1]).toBe('number');
+      }
+    });
+  });
+
+  describe('Invariant Tests', () => {
+    it('should maintain event invariants across all operations', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.organizerUser(),
+          async (event, user) => {
+            // Test findOne invariant
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+            const foundEvent = await service.findOne(event.id);
+            PropertyTestHelpers.assertEventInvariants(foundEvent);
+
+            // Test findByContractAddress invariant
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+            const foundByContract = await service.findByContractAddress(event.contractAddress);
+            if (foundByContract) {
+              PropertyTestHelpers.assertEventInvariants(foundByContract);
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain user role invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.createEventDto(),
+          fc.record({
+            organizerUser: ArbitraryGenerators.organizerUser(),
+            adminUser: ArbitraryGenerators.adminUser(),
+            regularUser: ArbitraryGenerators.regularUser(),
+          }),
+          async (createEventDto, users) => {
+            // Organizers should be able to create events
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+            jest.spyOn(eventRepository, 'create').mockReturnValue(PropertyTestHelpers.createMockEvent());
+            jest.spyOn(eventRepository, 'save').mockResolvedValue(PropertyTestHelpers.createMockEvent());
+
+            await expect(service.create(createEventDto, users.organizerUser)).resolves.toBeDefined();
+
+            // Admins should be able to create events
+            await expect(service.create(createEventDto, users.adminUser)).resolves.toBeDefined();
+
+            // Regular users should not be able to create events
+            await expect(service.create(createEventDto, users.regularUser)).rejects.toThrow();
+          }
+        ),
+        { numRuns: 30 }
+      );
+    });
+  });
+});

--- a/app/backend/test/fuzz.input-validation.spec.ts
+++ b/app/backend/test/fuzz.input-validation.spec.ts
@@ -1,0 +1,448 @@
+import { fc, test } from 'fast-check';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventsService } from '../src/events/events.service';
+import { UsersService } from '../src/users/users.service';
+import { AuthService } from '../src/auth/auth.service';
+import { Event } from '../src/events/entities/event.entity';
+import { User, UserRole } from '../src/users/entities/user.entity';
+import { CreateEventDto } from '../src/events/dto/create-event.dto';
+import { CreateUserDto } from '../src/users/dto/create-user.dto';
+import { FuzzTestHelpers } from './utils/property-test-utils';
+
+describe('Fuzz Testing for Input Validation', () => {
+  let eventsService: EventsService;
+  let usersService: UsersService;
+  let authService: AuthService;
+  let eventRepository: Repository<Event>;
+  let userRepository: Repository<User>;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        UsersService,
+        AuthService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            findAndCount: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    eventsService = module.get<EventsService>(EventsService);
+    usersService = module.get<UsersService>(UsersService);
+    authService = module.get<AuthService>(AuthService);
+    eventRepository = module.get<Repository<Event>>(getRepositoryToken(Event));
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('Malicious String Input Fuzzing', () => {
+    it('should handle malicious event names gracefully', async () => {
+      const maliciousInputs = FuzzTestHelpers.generateMaliciousStrings();
+      
+      for (const maliciousInput of maliciousInputs) {
+        try {
+          const createEventDto: CreateEventDto = {
+            name: maliciousInput,
+            description: 'Valid description',
+            contractAddress: '0x' + 'a'.repeat(40),
+            organizerId: 'valid-uuid',
+            startTime: new Date().toISOString(),
+            endTime: new Date(Date.now() + 3600000).toISOString(),
+          };
+
+          const user = { id: 'valid-uuid', roles: [UserRole.ORGANIZER] } as User;
+
+          // Should either succeed with sanitization or fail gracefully
+          jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+          jest.spyOn(eventRepository, 'create').mockReturnValue({ name: maliciousInput } as Event);
+          jest.spyOn(eventRepository, 'save').mockResolvedValue({ name: maliciousInput } as Event);
+          
+          const result = await eventsService.create(createEventDto, user);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should be a validation error, not a crash
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).not.toContain('Cannot read property'); // No null pointer exceptions
+        }
+      }
+    });
+
+    it('should handle malicious user data gracefully', async () => {
+      const maliciousInputs = FuzzTestHelpers.generateMaliciousStrings();
+      
+      for (const maliciousInput of maliciousInputs) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: maliciousInput,
+            lastName: maliciousInput,
+            email: 'valid@example.com',
+            bio: maliciousInput,
+          };
+
+          // Should either succeed with sanitization or fail gracefully
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: maliciousInput } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: maliciousInput } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should be a validation error, not a crash
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).not.toContain('Cannot read property');
+        }
+      }
+    });
+
+    it('should handle malicious search queries gracefully', async () => {
+      const maliciousQueries = FuzzTestHelpers.generateMaliciousStrings();
+      
+      for (const maliciousQuery of maliciousQueries) {
+        try {
+          jest.spyOn(userRepository, 'find').mockResolvedValue([]);
+          const result = await usersService.search(maliciousQuery);
+          expect(Array.isArray(result)).toBe(true);
+        } catch (error) {
+          // Should handle gracefully without database errors
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Extreme Input Values Fuzzing', () => {
+    it('should handle extremely long strings', async () => {
+      const extremeStrings = [
+        'a'.repeat(10000), // Very long string
+        '🔥'.repeat(5000), // Many emojis
+        ' '.repeat(10000), // Long whitespace
+        '\n'.repeat(1000), // Many newlines
+        '\t'.repeat(1000), // Many tabs
+      ];
+
+      for (const extremeString of extremeStrings) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: extremeString,
+            lastName: 'Valid',
+            email: 'valid@example.com',
+          };
+
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: extremeString } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: extremeString } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should fail with validation error, not crash
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle edge case numbers', async () => {
+      const edgeCaseNumbers = FuzzTestHelpers.generateEdgeCaseNumbers();
+      
+      for (const edgeNumber of edgeCaseNumbers) {
+        try {
+          // Test with pagination parameters
+          const result = await eventsService.findAll(
+            Math.max(1, Math.floor(edgeNumber as number) || 1),
+            Math.min(100, Math.max(1, Math.abs(edgeNumber as number) || 1))
+          );
+          expect(Array.isArray(result[0])).toBe(true);
+        } catch (error) {
+          // Should handle gracefully
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle edge case dates', async () => {
+      const edgeCaseDates = FuzzTestHelpers.generateEdgeCaseDates();
+      
+      for (const edgeDate of edgeCaseDates) {
+        try {
+          const createEventDto: CreateEventDto = {
+            name: 'Valid Event',
+            description: 'Valid description',
+            contractAddress: '0x' + 'a'.repeat(40),
+            organizerId: 'valid-uuid',
+            startTime: edgeDate.toISOString(),
+            endTime: new Date(edgeDate.getTime() + 3600000).toISOString(),
+          };
+
+          const user = { id: 'valid-uuid', roles: [UserRole.ORGANIZER] } as User;
+
+          jest.spyOn(eventRepository, 'findOne').mockResolvedValue(null);
+          jest.spyOn(eventRepository, 'create').mockReturnValue({ startTime: edgeDate } as Event);
+          jest.spyOn(eventRepository, 'save').mockResolvedValue({ startTime: edgeDate } as Event);
+          
+          const result = await eventsService.create(createEventDto, user);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should handle edge case dates gracefully
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Invalid Format Fuzzing', () => {
+    it('should handle invalid wallet addresses', async () => {
+      const invalidAddresses = FuzzTestHelpers.generateInvalidWalletAddresses();
+      
+      for (const invalidAddress of invalidAddresses) {
+        try {
+          await usersService.generateNonce(invalidAddress as string);
+          // Should either succeed or fail gracefully
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).not.toContain('Cannot read property');
+        }
+      }
+    });
+
+    it('should handle invalid emails', async () => {
+      const invalidEmails = FuzzTestHelpers.generateInvalidEmails();
+      
+      for (const invalidEmail of invalidEmails) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: 'Valid',
+            lastName: 'Valid',
+            email: invalidEmail as string,
+          };
+
+          await usersService.create(createUserDto);
+          // Should fail validation gracefully
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle invalid UUIDs', async () => {
+      const invalidUuids = [
+        '',
+        'not-a-uuid',
+        '123-456-789',
+        'x'.repeat(36),
+        '0'.repeat(36),
+        'z'.repeat(36),
+        ...FuzzTestHelpers.generateMaliciousStrings(),
+      ];
+      
+      for (const invalidUuid of invalidUuids) {
+        try {
+          await eventsService.findOne(invalidUuid);
+          // Should fail gracefully
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).not.toContain('Cannot read property');
+        }
+      }
+    });
+  });
+
+  describe('Boundary Condition Fuzzing', () => {
+    it('should handle pagination boundary conditions', async () => {
+      const boundaryValues = [
+        { page: 0, limit: 0 },    // Below minimum
+        { page: -1, limit: -1 },   // Negative values
+        { page: 1, limit: 1 },     // Minimum valid
+        { page: 1000000, limit: 1000000 }, // Very large values
+        { page: Number.MAX_SAFE_INTEGER, limit: 1 },
+        { page: 1, limit: Number.MAX_SAFE_INTEGER },
+      ];
+
+      for (const { page, limit } of boundaryValues) {
+        try {
+          const result = await eventsService.findAll(page, limit);
+          expect(Array.isArray(result[0])).toBe(true);
+        } catch (error) {
+          // Should handle boundary conditions gracefully
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle string length boundaries', async () => {
+      const boundaryStrings = [
+        '',                           // Empty
+        'a',                          // Minimum length 1
+        'a'.repeat(255),              // Common max length
+        'a'.repeat(256),              // Just over common max
+        'a'.repeat(1000),             // Large but reasonable
+        'a'.repeat(10000),           // Very large
+      ];
+
+      for (const boundaryString of boundaryStrings) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: boundaryString,
+            lastName: boundaryString,
+            email: 'valid@example.com',
+          };
+
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: boundaryString } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: boundaryString } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should handle length boundaries gracefully
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Encoding and Special Characters Fuzzing', () => {
+    it('should handle Unicode and special characters', async () => {
+      const specialInputs = [
+        '🔥💣🚀🌟✨',              // Emojis
+        'Café Münchner Freiheit', // German characters
+        '北京欢迎你',              // Chinese characters
+        'مرحبا',                 // Arabic characters
+        'привет',                // Cyrillic characters
+        '🏳️‍🌈🌈',                // Multi-byte emoji sequences
+        '\x00\x01\x02\x03',      // Control characters
+        '\u0000\u0001\u0002',    // Unicode control chars
+        'ñáéíóú',                // Accented characters
+        'ßüöä',                  // German umlauts
+      ];
+
+      for (const specialInput of specialInputs) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: specialInput,
+            lastName: 'Valid',
+            email: 'valid@example.com',
+          };
+
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: specialInput } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: specialInput } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should handle special characters gracefully
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle HTML and JavaScript injection attempts', async () => {
+      const injectionAttempts = [
+        '<script>alert("xss")</script>',
+        'javascript:alert("xss")',
+        '<img src=x onerror=alert("xss")>',
+        '${7*7}',                    // Template injection
+        '{{7*7}}',                  // Jinja2 injection
+        '<%=7*7%>',                 // ERB injection
+        'SELECT * FROM users',      // SQL injection
+        '../../etc/passwd',         // Path traversal
+        '${jndi:ldap://evil}',     // Log4j injection
+        '{{constructor.constructor("alert(1)")()}}', // Advanced template injection
+      ];
+
+      for (const injection of injectionAttempts) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: injection,
+            lastName: 'Valid',
+            email: 'valid@example.com',
+          };
+
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: injection } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: injection } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+          
+          // If it succeeds, ensure the injection was neutralized
+          expect(result.firstName).not.toContain('<script>');
+        } catch (error) {
+          // Should reject injection attempts
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Resource Exhaustion Fuzzing', () => {
+    it('should handle memory pressure gracefully', async () => {
+      const memoryIntensiveInputs = [
+        'a'.repeat(1000000),        // 1MB string
+        '🔥'.repeat(100000),        // 400KB of emojis
+        Array(10000).fill('test').join(','), // Large array
+      ];
+
+      for (const memoryIntensiveInput of memoryIntensiveInputs) {
+        try {
+          const createUserDto: CreateUserDto = {
+            firstName: memoryIntensiveInput.slice(0, 50), // Truncate to be reasonable
+            lastName: 'Valid',
+            email: 'valid@example.com',
+          };
+
+          jest.spyOn(userRepository, 'create').mockReturnValue({ firstName: memoryIntensiveInput } as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue({ firstName: memoryIntensiveInput } as User);
+          
+          const result = await usersService.create(createUserDto);
+          expect(result).toBeDefined();
+        } catch (error) {
+          // Should handle memory pressure gracefully
+          expect(error).toBeInstanceOf(Error);
+          expect(error.message).not.toContain('out of memory');
+        }
+      }
+    });
+
+    it('should handle rapid sequential requests', async () => {
+      const rapidRequests = Array(100).fill(null).map((_, i) => ({
+        firstName: `User${i}`,
+        lastName: 'Test',
+        email: `user${i}@example.com`,
+      }));
+
+      try {
+        for (const userData of rapidRequests) {
+          jest.spyOn(userRepository, 'create').mockReturnValue(userData as User);
+          jest.spyOn(userRepository, 'save').mockResolvedValue(userData as User);
+          
+          const result = await usersService.create(userData);
+          expect(result).toBeDefined();
+        }
+      } catch (error) {
+        // Should handle rapid requests gracefully
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/app/backend/test/invariants.consistency.spec.ts
+++ b/app/backend/test/invariants.consistency.spec.ts
@@ -1,0 +1,427 @@
+import { fc, test } from 'fast-check';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventsService } from '../src/events/events.service';
+import { Event } from '../src/events/entities/event.entity';
+import { User, UserRole } from '../src/users/entities/user.entity';
+import { UsersService } from '../src/users/users.service';
+import { AuthService } from '../src/auth/auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { SessionsService } from '../src/sessions/sessions.service';
+import { WebhookService } from '../src/webhooks/services/webhook.service';
+import { ArbitraryGenerators, PropertyTestHelpers } from './utils/property-test-utils';
+
+describe('Data Consistency Invariant Tests', () => {
+  let eventsService: EventsService;
+  let usersService: UsersService;
+  let authService: AuthService;
+  let eventRepository: Repository<Event>;
+  let userRepository: Repository<User>;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        EventsService,
+        UsersService,
+        AuthService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            findAndCount: jest.fn(),
+            update: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn(),
+            verify: jest.fn(),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn(),
+          },
+        },
+        {
+          provide: SessionsService,
+          useValue: {
+            createSession: jest.fn(),
+          },
+        },
+        {
+          provide: WebhookService,
+          useValue: {
+            trigger: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    eventsService = module.get<EventsService>(EventsService);
+    usersService = module.get<UsersService>(UsersService);
+    authService = module.get<AuthService>(AuthService);
+    eventRepository = module.get<Repository<Event>>(getRepositoryToken(Event));
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('Event-User Relationship Invariants', () => {
+    it('should maintain organizer relationship consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.organizerUser(),
+          async (event, organizer) => {
+            // Arrange
+            event.organizerId = organizer.id;
+            
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(organizer);
+
+            // Act
+            const foundEvent = await eventsService.findOne(event.id);
+
+            // Assert invariants
+            expect(foundEvent.organizerId).toBe(organizer.id);
+            PropertyTestHelpers.assertUserInvariants(organizer);
+            PropertyTestHelpers.assertEventInvariants(foundEvent);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should prevent orphan events', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          async (event) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+            // Act & Assert
+            const foundEvent = await eventsService.findOne(event.id);
+            
+            // Event should exist but organizer might be missing in some cases
+            expect(foundEvent).toBeDefined();
+            expect(foundEvent.organizerId).toBeDefined();
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('User Role Invariants', () => {
+    it('should maintain role hierarchy consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+
+            // Act
+            const foundUser = await usersService.findById(user.id);
+
+            // Assert invariants
+            expect(foundUser.roles).toBeDefined();
+            expect(foundUser.roles.length).toBeGreaterThan(0);
+            
+            // All roles should be valid enum values
+            foundUser.roles.forEach(role => {
+              expect(Object.values(UserRole)).toContain(role);
+            });
+
+            // Admin should have all permissions implicitly
+            if (foundUser.roles.includes(UserRole.ADMIN)) {
+              expect(foundUser.roles.length).toBeGreaterThanOrEqual(1);
+            }
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should maintain wallet address uniqueness invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+
+            // Act
+            const foundUser = await usersService.findOneByWallet(user.walletAddress);
+
+            // Assert invariants
+            if (foundUser) {
+              PropertyTestHelpers.assertWalletAddressInvariants(foundUser.walletAddress);
+              expect(foundUser.walletAddress).toBe(user.walletAddress);
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Event Date Invariants', () => {
+    it('should maintain temporal consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          async (event) => {
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+
+            // Act
+            const foundEvent = await eventsService.findOne(event.id);
+
+            // Assert temporal invariants
+            expect(foundEvent.startTime).toBeDefined();
+            expect(foundEvent.startTime).toBeInstanceOf(Date);
+            
+            if (foundEvent.endTime) {
+              expect(foundEvent.endTime).toBeInstanceOf(Date);
+              expect(foundEvent.endTime.getTime()).toBeGreaterThanOrEqual(foundEvent.startTime.getTime());
+            }
+
+            // Creation timestamps should be consistent
+            expect(foundEvent.createdAt).toBeInstanceOf(Date);
+            expect(foundEvent.updatedAt).toBeInstanceOf(Date);
+            expect(foundEvent.updatedAt.getTime()).toBeGreaterThanOrEqual(foundEvent.createdAt.getTime());
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should handle edge case date combinations', async () => {
+      await test(
+        fc.asyncProperty(
+          fc.date(),
+          fc.option(fc.date()),
+          async (startTime, endTime) => {
+            // Create event with potentially problematic dates
+            const event = PropertyTestHelpers.createMockEvent({
+              startTime,
+              endTime: endTime && endTime < startTime ? startTime : endTime,
+            });
+
+            // Arrange
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+
+            // Act
+            const foundEvent = await eventsService.findOne(event.id);
+
+            // Assert that the system handles edge cases gracefully
+            expect(foundEvent.startTime).toBeInstanceOf(Date);
+            if (foundEvent.endTime) {
+              expect(foundEvent.endTime.getTime()).toBeGreaterThanOrEqual(foundEvent.startTime.getTime());
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Authentication Token Invariants', () => {
+    it('should maintain token payload consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          fc.string({ minLength: 32 }),
+          fc.string({ minLength: 32 }),
+          async (user, accessToken, refreshToken) => {
+            // Arrange
+            const payload = {
+              sub: user.id,
+              wallet: user.walletAddress,
+              roles: user.roles,
+            };
+
+            jest.spyOn(authService['jwtService'], 'verify').mockReturnValue(payload);
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+            jest.spyOn(authService['configService'], 'get').mockReturnValue('test-secret');
+
+            // Act
+            const validatedUser = await authService.validateToken(accessToken);
+
+            // Assert token invariants
+            expect(validatedUser.id).toBe(user.id);
+            expect(validatedUser.walletAddress).toBe(user.walletAddress);
+            expect(validatedUser.roles).toEqual(user.roles);
+            PropertyTestHelpers.assertUserInvariants(validatedUser);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should maintain token expiration consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            const mockAccessToken = 'access-token';
+            const mockRefreshToken = 'refresh-token';
+            
+            jest.spyOn(authService['jwtService'], 'sign')
+              .mockReturnValueOnce(mockAccessToken)
+              .mockReturnValueOnce(mockRefreshToken);
+            jest.spyOn(authService['sessionsService'], 'createSession').mockResolvedValue(undefined);
+            jest.spyOn(authService['configService'], 'get').mockReturnValue('test-secret');
+
+            // Act
+            const tokens = await authService.generateTokens(user);
+
+            // Assert token generation invariants
+            expect(tokens).toHaveProperty('accessToken');
+            expect(tokens).toHaveProperty('refreshToken');
+            expect(typeof tokens.accessToken).toBe('string');
+            expect(typeof tokens.refreshToken).toBe('string');
+            expect(tokens.accessToken.length).toBeGreaterThan(0);
+            expect(tokens.refreshToken.length).toBeGreaterThan(0);
+
+            // Verify JWT was called with correct expiration times
+            expect(authService['jwtService'].sign).toHaveBeenCalledWith(
+              expect.any(Object),
+              expect.objectContaining({ expiresIn: '15m' }) // Access token
+            );
+            
+            expect(authService['jwtService'].sign).toHaveBeenCalledWith(
+              expect.any(Object),
+              expect.objectContaining({ expiresIn: '7d' }) // Refresh token
+            );
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Profile Completion Invariants', () => {
+    it('should maintain completion percentage bounds', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+
+            // Act
+            const foundUser = await usersService.findById(user.id);
+
+            // Assert completion invariants
+            expect(typeof foundUser.profileCompletion).toBe('number');
+            expect(foundUser.profileCompletion).toBeGreaterThanOrEqual(0);
+            expect(foundUser.profileCompletion).toBeLessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should maintain completion calculation consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Test that completion is calculated based on filled fields
+            const filledFields = [
+              user.firstName,
+              user.lastName,
+              user.bio,
+              user.avatarUrl,
+              user.socialLinks && Object.keys(user.socialLinks).length > 0,
+              user.preferences && Object.keys(user.preferences).length > 0,
+            ].filter(Boolean).length;
+
+            const totalFields = 6;
+            const expectedCompletion = Math.round((filledFields / totalFields) * 100);
+
+            // The actual completion should be reasonable
+            expect(user.profileCompletion).toBeGreaterThanOrEqual(0);
+            expect(user.profileCompletion).toBeLessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Cross-Service Data Consistency', () => {
+    it('should maintain user consistency across services', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange - same user should be consistent across different services
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(user);
+
+            // Act - retrieve user through different service methods
+            const userFromUsersService = await usersService.findById(user.id);
+            const userFromAuthService = await authService.validateToken('valid-token');
+
+            // Assert cross-service consistency
+            expect(userFromUsersService.id).toBe(user.id);
+            expect(userFromAuthService.id).toBe(user.id);
+            expect(userFromUsersService.walletAddress).toBe(user.walletAddress);
+            expect(userFromAuthService.walletAddress).toBe(user.walletAddress);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain event ownership consistency', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.event(),
+          ArbitraryGenerators.organizerUser(),
+          async (event, organizer) => {
+            // Arrange
+            event.organizerId = organizer.id;
+            jest.spyOn(eventRepository, 'findOne').mockResolvedValue(event);
+            jest.spyOn(userRepository, 'findOne').mockResolvedValue(organizer);
+
+            // Act
+            const foundEvent = await eventsService.findOne(event.id);
+            const foundOrganizer = await usersService.findById(organizer.id);
+
+            // Assert ownership consistency
+            expect(foundEvent.organizerId).toBe(foundOrganizer.id);
+            expect(foundOrganizer.roles).toContain(UserRole.ORGANIZER);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+});

--- a/app/backend/test/setup.ts
+++ b/app/backend/test/setup.ts
@@ -1,0 +1,35 @@
+// Jest setup file for property-based testing
+// This file runs before each test file
+
+// Set default timeout for property-based tests
+jest.setTimeout(30000);
+
+// Global test utilities
+global.fc = require('fast-check');
+
+// Mock console methods to reduce noise during property testing
+const originalConsole = { ...console };
+
+beforeEach(() => {
+  // Suppress console logs during property tests to reduce noise
+  console.log = jest.fn();
+  console.info = jest.fn();
+  console.debug = jest.fn();
+});
+
+afterEach(() => {
+  // Restore console methods
+  Object.assign(console, originalConsole);
+});
+
+// Handle unhandled promise rejections in property tests
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+});
+
+// Set up global test configuration for fast-check
+global.testConfig = {
+  numRuns: process.env.TEST_NUM_RUNS ? parseInt(process.env.TEST_NUM_RUNS) : 100,
+  timeout: process.env.TEST_TIMEOUT ? parseInt(process.env.TEST_TIMEOUT) : 30000,
+  verbose: process.env.TEST_VERBOSE === 'true',
+};

--- a/app/backend/test/users.service.property.spec.ts
+++ b/app/backend/test/users.service.property.spec.ts
@@ -1,0 +1,507 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, ILike } from 'typeorm';
+import { fc, test } from 'fast-check';
+import { UsersService } from '../src/users/users.service';
+import { User, ProfileVisibility } from '../src/users/entities/user.entity';
+import { CreateUserDto } from '../src/users/dto/create-user.dto';
+import { UpdateUserDto } from '../src/users/dto/update-user.dto';
+import { UpdatePreferencesDto } from '../src/users/dto/update-preferences.dto';
+import { UpdateSocialLinksDto } from '../src/users/dto/update-social-links.dto';
+import { WebhookService } from '../src/webhooks/services/webhook.service';
+import { WebhookEventType } from '../src/webhooks/constants/webhook.constants';
+import { ArbitraryGenerators, PropertyTestHelpers, FuzzTestHelpers } from './utils/property-test-utils';
+
+describe('UsersService Property-Based Tests', () => {
+  let service: UsersService;
+  let usersRepository: Repository<User>;
+  let webhookService: WebhookService;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      providers: [
+        UsersService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            findOne: jest.fn(),
+            find: jest.fn(),
+            remove: jest.fn(),
+          },
+        },
+        {
+          provide: WebhookService,
+          useValue: {
+            trigger: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<UsersService>(UsersService);
+    usersRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    webhookService = module.get<WebhookService>(WebhookService);
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  describe('User Creation Property Tests', () => {
+    it('should maintain invariants when creating users with valid data', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            const createUserDto: CreateUserDto = {
+              email: user.email,
+              firstName: user.firstName || 'Test',
+              lastName: user.lastName || 'User',
+              bio: user.bio,
+            };
+
+            jest.spyOn(usersRepository, 'create').mockReturnValue(user);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(user);
+            jest.spyOn(webhookService, 'trigger').mockResolvedValue(undefined);
+
+            // Act
+            const result = await service.create(createUserDto);
+
+            // Assert
+            PropertyTestHelpers.assertUserInvariants(result);
+            expect(result.email).toBe(createUserDto.email);
+            expect(result.firstName).toBe(createUserDto.firstName);
+            expect(result.lastName).toBe(createUserDto.lastName);
+            expect(webhookService.trigger).toHaveBeenCalledWith(WebhookEventType.USER_CREATED, result);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should calculate profile completion correctly', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            const createUserDto: CreateUserDto = {
+              email: user.email,
+              firstName: user.firstName || 'Test',
+              lastName: user.lastName || 'User',
+              bio: user.bio,
+            };
+
+            const userWithCompletion = { ...user, profileCompletion: 50 };
+            jest.spyOn(usersRepository, 'create').mockReturnValue(userWithCompletion);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(userWithCompletion);
+            jest.spyOn(webhookService, 'trigger').mockResolvedValue(undefined);
+
+            // Act
+            const result = await service.create(createUserDto);
+
+            // Assert
+            expect(typeof result.profileCompletion).toBe('number');
+            expect(result.profileCompletion).toBeGreaterThanOrEqual(0);
+            expect(result.profileCompletion).toBeLessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('User Retrieval Property Tests', () => {
+    it('should return valid user structure when found', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+
+            // Act
+            const result = await service.findById(user.id);
+
+            // Assert
+            PropertyTestHelpers.assertUserInvariants(result);
+            expect(result.id).toBe(user.id);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should throw NotFoundException for non-existent users', async () => {
+      await test(
+        fc.asyncProperty(
+          fc.uuid(),
+          async (userId) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
+
+            // Act & Assert
+            await expect(service.findById(userId)).rejects.toThrow('User not found');
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should enforce privacy settings for public profiles', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user().map(user => ({
+            ...user,
+            profileVisibility: ProfileVisibility.PRIVATE,
+          })),
+          async (privateUser) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(privateUser);
+
+            // Act & Assert
+            await expect(service.findPublicProfile(privateUser.id)).rejects.toThrow('Profile is private');
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should return public profile data for public users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user().map(user => ({
+            ...user,
+            profileVisibility: ProfileVisibility.PUBLIC,
+          })),
+          async (publicUser) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(publicUser);
+
+            // Act
+            const result = await service.findPublicProfile(publicUser.id);
+
+            // Assert
+            expect(result).not.toHaveProperty('email');
+            expect(result).not.toHaveProperty('preferences');
+            expect(result).toHaveProperty('id');
+            expect(result).toHaveProperty('walletAddress');
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('User Update Property Tests', () => {
+    it('should maintain invariants when updating users', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          ArbitraryGenerators.updateUserDto(),
+          async (user, updateUserDto) => {
+            // Arrange
+            const updatedUser = { ...user, ...updateUserDto, profileCompletion: 75 };
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(updatedUser);
+
+            // Act
+            const result = await service.update(user.id, updateUserDto);
+
+            // Assert
+            PropertyTestHelpers.assertUserInvariants(result);
+            if (updateUserDto.firstName) expect(result.firstName).toBe(updateUserDto.firstName);
+            if (updateUserDto.lastName) expect(result.lastName).toBe(updateUserDto.lastName);
+            if (updateUserDto.bio !== undefined) expect(result.bio).toBe(updateUserDto.bio);
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should recalculate profile completion on updates', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          ArbitraryGenerators.updateUserDto(),
+          async (user, updateUserDto) => {
+            // Arrange
+            const updatedUser = { ...user, ...updateUserDto, profileCompletion: 85 };
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(updatedUser);
+
+            // Act
+            const result = await service.update(user.id, updateUserDto);
+
+            // Assert
+            expect(typeof result.profileCompletion).toBe('number');
+            expect(result.profileCompletion).toBeGreaterThanOrEqual(0);
+            expect(result.profileCompletion).toBeLessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('User Search Property Tests', () => {
+    it('should return valid user structures for search queries', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          fc.string({ minLength: 1, maxLength: 50 }),
+          async (user, query) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'find').mockResolvedValue([user]);
+
+            // Act
+            const result = await service.search(query);
+
+            // Assert
+            expect(Array.isArray(result)).toBe(true);
+            if (result.length > 0) {
+              PropertyTestHelpers.assertUserInvariants(result[0]);
+            }
+            expect(result.length).toBeLessThanOrEqual(20); // Search limit
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should handle empty search results gracefully', async () => {
+      await test(
+        fc.asyncProperty(
+          fc.string({ minLength: 1, maxLength: 50 }),
+          async (query) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'find').mockResolvedValue([]);
+
+            // Act
+            const result = await service.search(query);
+
+            // Assert
+            expect(Array.isArray(result)).toBe(true);
+            expect(result.length).toBe(0);
+          }
+        ),
+        { numRuns: 30 }
+      );
+    });
+  });
+
+  describe('Wallet Authentication Property Tests', () => {
+    it('should generate valid nonces for wallet addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          ArbitraryGenerators.nonce(),
+          async (walletAddress, nonce) => {
+            // Arrange
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(undefined);
+
+            // Act
+            const result = await service.generateNonce(walletAddress);
+
+            // Assert
+            expect(typeof result).toBe('string');
+            expect(result.length).toBeGreaterThan(0);
+            expect(result).toMatch(/^[a-f0-9]{32}$/); // 16 bytes = 32 hex chars
+          }
+        ),
+        { numRuns: 100 }
+      );
+    });
+
+    it('should validate nonces correctly', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          ArbitraryGenerators.nonce(),
+          async (user, nonce) => {
+            // Arrange
+            user.nonce = nonce;
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(user);
+
+            // Act
+            const result = await service.validateNonce(user.walletAddress, nonce);
+
+            // Assert
+            expect(result).toBe(true);
+            expect(user.nonce).toBeNull(); // Nonce should be cleared
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should reject invalid nonces', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          ArbitraryGenerators.nonce(),
+          async (user, wrongNonce) => {
+            // Arrange
+            user.nonce = 'different-nonce';
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+
+            // Act
+            const result = await service.validateNonce(user.walletAddress, wrongNonce);
+
+            // Assert
+            expect(result).toBe(false);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should create users from wallet addresses', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.walletAddress(),
+          async (walletAddress) => {
+            // Arrange
+            const expectedUser = {
+              id: fc.sample(fc.uuid(), 1)[0],
+              walletAddress,
+              firstName: 'User',
+              lastName: walletAddress.substring(0, 6),
+              email: `${walletAddress}@wallet.local`,
+              profileVisibility: ProfileVisibility.PUBLIC,
+              profileCompletion: expect.any(Number),
+              createdAt: expect.any(Date),
+              updatedAt: expect.any(Date),
+            };
+
+            jest.spyOn(usersRepository, 'create').mockReturnValue(expectedUser);
+            jest.spyOn(usersRepository, 'save').mockResolvedValue(expectedUser);
+
+            // Act
+            const result = await service.createFromWallet(walletAddress);
+
+            // Assert
+            expect(result.walletAddress).toBe(walletAddress);
+            expect(result.firstName).toBe('User');
+            expect(result.lastName).toBe(walletAddress.substring(0, 6));
+            expect(result.email).toBe(`${walletAddress}@wallet.local`);
+            expect(result.profileVisibility).toBe(ProfileVisibility.PUBLIC);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+
+  describe('Fuzz Tests for User Management', () => {
+    it('should handle malicious input in search queries gracefully', async () => {
+      const maliciousQueries = FuzzTestHelpers.generateMaliciousStrings();
+      
+      for (const query of maliciousQueries) {
+        try {
+          jest.spyOn(usersRepository, 'find').mockResolvedValue([]);
+          const result = await service.search(query);
+          expect(Array.isArray(result)).toBe(true);
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle extreme wallet addresses in auth methods', async () => {
+      const invalidAddresses = FuzzTestHelpers.generateInvalidWalletAddresses();
+      
+      for (const walletAddress of invalidAddresses) {
+        try {
+          jest.spyOn(usersRepository, 'findOne').mockResolvedValue(null);
+          jest.spyOn(usersRepository, 'save').mockResolvedValue(undefined);
+          const nonce = await service.generateNonce(walletAddress as string);
+          expect(typeof nonce).toBe('string');
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+
+    it('should handle edge case user data in updates', async () => {
+      const edgeCases = [
+        { firstName: '', lastName: '', bio: '', email: 'valid@example.com' },
+        { firstName: 'a'.repeat(1000), lastName: 'b'.repeat(1000), bio: 'c'.repeat(5000) },
+        { firstName: '🔥💣🚀', lastName: '🌟✨', bio: '🎉🎊🎈' },
+      ];
+
+      for (const updateData of edgeCases) {
+        try {
+          const user = PropertyTestHelpers.createMockUser();
+          const updatedUser = { ...user, ...updateData, profileCompletion: 50 };
+          
+          jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+          jest.spyOn(usersRepository, 'save').mockResolvedValue(updatedUser);
+          
+          const result = await service.update(user.id, updateData);
+          expect(result).toBeDefined();
+        } catch (error) {
+          expect(error).toBeInstanceOf(Error);
+        }
+      }
+    });
+  });
+
+  describe('Invariant Tests', () => {
+    it('should maintain user invariants across all operations', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Test findById invariant
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+            const foundUser = await service.findById(user.id);
+            PropertyTestHelpers.assertUserInvariants(foundUser);
+
+            // Test findOneByWallet invariant
+            jest.spyOn(usersRepository, 'findOne').mockResolvedValue(user);
+            const foundByWallet = await service.findOneByWallet(user.walletAddress);
+            if (foundByWallet) {
+              PropertyTestHelpers.assertUserInvariants(foundByWallet);
+            }
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain profile completion invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Profile completion should always be between 0 and 100
+            expect(typeof user.profileCompletion).toBe('number');
+            expect(user.profileCompletion).toBeGreaterThanOrEqual(0);
+            expect(user.profileCompletion).toBeLessThanOrEqual(100);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+
+    it('should maintain wallet address format invariants', async () => {
+      await test(
+        fc.asyncProperty(
+          ArbitraryGenerators.user(),
+          async (user) => {
+            // Wallet address should maintain format
+            PropertyTestHelpers.assertWalletAddressInvariants(user.walletAddress);
+          }
+        ),
+        { numRuns: 50 }
+      );
+    });
+  });
+});

--- a/app/backend/test/utils/property-test-utils.ts
+++ b/app/backend/test/utils/property-test-utils.ts
@@ -1,0 +1,302 @@
+import { fc } from 'fast-check';
+import { User, UserRole } from '../src/users/entities/user.entity';
+import { Event } from '../src/events/entities/event.entity';
+import { CreateEventDto } from '../src/events/dto/create-event.dto';
+import { UpdateEventDto } from '../src/events/dto/update-event.dto';
+
+export class ArbitraryGenerators {
+  static user() {
+    return fc.record({
+      id: fc.uuid(),
+      email: fc.emailAddress(),
+      walletAddress: fc.hexaString({ minLength: 42, maxLength: 42 }).map(s => '0x' + s.slice(2)),
+      roles: fc.array(fc.constantFrom(...Object.values(UserRole)), { minLength: 1 }),
+      isActive: fc.boolean(),
+      createdAt: fc.date(),
+      updatedAt: fc.date(),
+    });
+  }
+
+  static organizerUser() {
+    return this.user().map(user => ({
+      ...user,
+      roles: [UserRole.ORGANIZER],
+    }));
+  }
+
+  static adminUser() {
+    return this.user().map(user => ({
+      ...user,
+      roles: [UserRole.ADMIN],
+    }));
+  }
+
+  static regularUser() {
+    return this.user().map(user => ({
+      ...user,
+      roles: [UserRole.USER],
+    }));
+  }
+
+  static event() {
+    return fc.record({
+      id: fc.uuid(),
+      name: fc.lorem({ maxCount: 3 }),
+      description: fc.option(fc.lorem({ maxCount: 10 })),
+      contractAddress: fc.hexaString({ minLength: 42, maxLength: 42 }).map(s => '0x' + s.slice(2)),
+      organizerId: fc.uuid(),
+      startTime: fc.date(),
+      endTime: fc.option(fc.date()),
+      createdAt: fc.date(),
+      updatedAt: fc.date(),
+    });
+  }
+
+  static createUserDto() {
+    return fc.record({
+      firstName: fc.string({ minLength: 1, maxLength: 50 }),
+      lastName: fc.string({ minLength: 1, maxLength: 50 }),
+      email: fc.emailAddress(),
+      bio: fc.option(fc.string({ maxLength: 500 })),
+    });
+  }
+
+  static updateUserDto() {
+    return fc.record({
+      firstName: fc.option(fc.string({ minLength: 1, maxLength: 50 })),
+      lastName: fc.option(fc.string({ minLength: 1, maxLength: 50 })),
+      email: fc.option(fc.emailAddress()),
+      bio: fc.option(fc.string({ maxLength: 500 })),
+      profileVisibility: fc.option(fc.constantFrom(...Object.values(ProfileVisibility))),
+    });
+  }
+
+  static validEventDates() {
+    return fc.tuple(fc.date(), fc.option(fc.date())).map(([startTime, endTime]) => {
+      const validEndTime = endTime && endTime > startTime ? endTime : new Date(startTime.getTime() + 3600000);
+      return { startTime, endTime: validEndTime };
+    });
+  }
+
+  static walletAddress() {
+    return fc.hexaString({ minLength: 40, maxLength: 40 }).map(s => '0x' + s);
+  }
+
+  static nonce() {
+    return fc.hexaString({ minLength: 16, maxLength: 32 });
+  }
+
+  static email() {
+    return fc.emailAddress();
+  }
+
+  static paginationParams() {
+    return fc.record({
+      page: fc.nat({ max: 1000 }),
+      limit: fc.nat({ min: 1, max: 100 }),
+    });
+  }
+
+  static stringWithConstraints(minLength = 1, maxLength = 1000) {
+    return fc.string({ minLength, maxLength });
+  }
+
+  static stringWithSpecialChars() {
+    return fc.string({ minLength: 1, maxLength: 100 }).map(s => 
+      s + '!@#$%^&*()_+-=[]{}|;:,.<>?'.charAt(Math.floor(Math.random() * 25))
+    );
+  }
+
+  static unicodeString() {
+    return fc.unicodeString({ minLength: 1, maxLength: 100 });
+  }
+
+  static largeNumber() {
+    return fc.bigInt({ min: BigInt(Number.MIN_SAFE_INTEGER), max: BigInt(Number.MAX_SAFE_INTEGER) });
+  }
+
+  static timestamp() {
+    return fc.date().getTime();
+  }
+}
+
+export class PropertyTestHelpers {
+  static assertEventInvariants(event: Event) {
+    expect(event.id).toBeDefined();
+    expect(event.name).toBeDefined();
+    expect(event.contractAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    
+    if (event.startTime && event.endTime) {
+      expect(event.endTime.getTime()).toBeGreaterThanOrEqual(event.startTime.getTime());
+    }
+    
+    expect(event.createdAt).toBeDefined();
+    expect(event.updatedAt).toBeDefined();
+  }
+
+  static assertUserInvariants(user: User) {
+    expect(user.id).toBeDefined();
+    expect(user.email).toMatch(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+    expect(user.walletAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
+    expect(user.firstName).toBeDefined();
+    expect(user.lastName).toBeDefined();
+    expect(user.roles).toBeDefined();
+    expect(user.roles.length).toBeGreaterThan(0);
+    expect(user.profileCompletion).toBeGreaterThanOrEqual(0);
+    expect(user.profileCompletion).toBeLessThanOrEqual(100);
+    expect(user.createdAt).toBeDefined();
+    expect(user.updatedAt).toBeDefined();
+  }
+
+  static assertPaginationInvariants(page: number, limit: number, totalItems: number) {
+    expect(page).toBeGreaterThan(0);
+    expect(limit).toBeGreaterThan(0);
+    expect(limit).toBeLessThanOrEqual(100);
+    
+    const totalPages = Math.ceil(totalItems / limit);
+    expect(page).toBeLessThanOrEqual(totalPages || 1);
+  }
+
+  static assertDateOrderInvariants(startDate: Date, endDate?: Date) {
+    if (endDate) {
+      expect(endDate.getTime()).toBeGreaterThanOrEqual(startDate.getTime());
+    }
+  }
+
+  static assertWalletAddressInvariants(address: string) {
+    expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/);
+  }
+
+  static assertEmailInvariants(email: string) {
+    expect(email).toMatch(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+  }
+
+  static assertTokenInvariants(tokens: { accessToken: string; refreshToken: string }) {
+    expect(tokens).toHaveProperty('accessToken');
+    expect(tokens).toHaveProperty('refreshToken');
+    expect(typeof tokens.accessToken).toBe('string');
+    expect(typeof tokens.refreshToken).toBe('string');
+    expect(tokens.accessToken.length).toBeGreaterThan(0);
+    expect(tokens.refreshToken.length).toBeGreaterThan(0);
+  }
+
+  static assertStringConstraints(str: string, minLength: number, maxLength: number) {
+    expect(str.length).toBeGreaterThanOrEqual(minLength);
+    expect(str.length).toBeLessThanOrEqual(maxLength);
+  }
+
+  static createMockUser(overrides: Partial<User> = {}): User {
+    return {
+      id: overrides.id || fc.sample(fc.uuid(), 1)[0],
+      firstName: overrides.firstName || fc.sample(fc.string({ minLength: 1, maxLength: 50 }), 1)[0],
+      lastName: overrides.lastName || fc.sample(fc.string({ minLength: 1, maxLength: 50 }), 1)[0],
+      email: overrides.email || fc.sample(fc.emailAddress(), 1)[0],
+      walletAddress: overrides.walletAddress || fc.sample(fc.hexaString({ minLength: 42, maxLength: 42 }).map(s => '0x' + s.slice(2)), 1)[0],
+      nonce: overrides.nonce !== undefined ? overrides.nonce : null,
+      roles: overrides.roles || [UserRole.ATTENDEE],
+      linkedWallets: overrides.linkedWallets || [],
+      oauthProviders: overrides.oauthProviders || [],
+      profileVisibility: overrides.profileVisibility || ProfileVisibility.PUBLIC,
+      preferences: overrides.preferences !== undefined ? overrides.preferences : undefined,
+      socialLinks: overrides.socialLinks !== undefined ? overrides.socialLinks : undefined,
+      username: overrides.username !== undefined ? overrides.username : undefined,
+      avatar: overrides.avatar !== undefined ? overrides.avatar : undefined,
+      bio: overrides.bio !== undefined ? overrides.bio : undefined,
+      profileCompletion: overrides.profileCompletion || 0,
+      avatarUrl: overrides.avatarUrl !== undefined ? overrides.avatarUrl : undefined,
+      isActive: overrides.isActive ?? true,
+      createdAt: overrides.createdAt || new Date(),
+      updatedAt: overrides.updatedAt || new Date(),
+      ...overrides,
+    };
+  }
+
+  static createMockEvent(overrides: Partial<Event> = {}): Event {
+    const startTime = overrides.startTime || new Date();
+    const endTime = overrides.endTime || new Date(startTime.getTime() + 3600000);
+    
+    return {
+      id: overrides.id || fc.sample(fc.uuid(), 1)[0],
+      name: overrides.name || fc.sample(fc.lorem({ maxCount: 3 }), 1)[0],
+      description: overrides.description !== undefined ? overrides.description : fc.sample(fc.option(fc.lorem({ maxCount: 10 })), 1)[0],
+      contractAddress: overrides.contractAddress || fc.sample(ArbitraryGenerators.walletAddress(), 1)[0],
+      organizerId: overrides.organizerId || fc.sample(fc.uuid(), 1)[0],
+      startTime,
+      endTime,
+      createdAt: overrides.createdAt || new Date(),
+      updatedAt: overrides.updatedAt || new Date(),
+      ...overrides,
+    };
+  }
+}
+
+export class FuzzTestHelpers {
+  static generateMaliciousStrings() {
+    return [
+      '../../etc/passwd',
+      '<script>alert("xss")</script>',
+      'DROP TABLE users; --',
+      '\x00\x01\x02\x03',
+      '🔥💣🚀🌟',
+      String.fromCharCode(0), // null byte
+      '\n\r\t',
+      ' '.repeat(10000), // very long whitespace
+      'a'.repeat(100000), // very long string
+    ];
+  }
+
+  static generateEdgeCaseNumbers() {
+    return [
+      Number.MAX_SAFE_INTEGER,
+      Number.MIN_SAFE_INTEGER,
+      0,
+      -1,
+      1,
+      Number.MAX_VALUE,
+      Number.MIN_VALUE,
+      Infinity,
+      -Infinity,
+      NaN,
+    ];
+  }
+
+  static generateEdgeCaseDates() {
+    return [
+      new Date(0), // Unix epoch
+      new Date('1970-01-01T00:00:00.000Z'),
+      new Date('2038-01-19T03:14:07.000Z'), // 32-bit timestamp limit
+      new Date('9999-12-31T23:59:59.999Z'), // Far future
+      new Date('0001-01-01T00:00:00.000Z'), // Far past
+    ];
+  }
+
+  static generateInvalidWalletAddresses() {
+    return [
+      '0x', // too short
+      '0x123', // too short
+      '0x' + 'a'.repeat(41), // wrong length
+      '0x' + 'g'.repeat(40), // invalid hex
+      '123' + '0x' + 'a'.repeat(40), // wrong prefix
+      '0x' + 'A'.repeat(40), // uppercase (should be lowercase)
+      '', // empty
+      null,
+      undefined,
+    ];
+  }
+
+  static generateInvalidEmails() {
+    return [
+      'invalid-email',
+      '@domain.com',
+      'user@',
+      'user..name@domain.com',
+      'user@.domain.com',
+      'user@domain.',
+      'user name@domain.com',
+      'user@domain..com',
+      '',
+      null,
+      undefined,
+    ];
+  }
+}


### PR DESCRIPTION
- Add fast-check dependency for property-based testing
- Create property-based tests for EventsService, AuthService, and UserService
- Add invariant testing for data consistency across services
- Implement fuzz testing for input validation and security
- Create test utilities and generators for reusable test data
- Update Jest configuration with extended timeouts and test scripts
- Add comprehensive documentation for property-based testing approach

Addresses issue #318: Missing Property-Based Tests

closes #318 