### PR TITLE
feat: add Dockerfile and .dockerignore for NestJS backend service (#417)

### DIFF
--- a/app/backend/.dockerignore
+++ b/app/backend/.dockerignore
@@ -1,0 +1,67 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+
+# Build output
+dist/
+build/
+
+# Testing
+coverage/
+.nyc_output/
+test/
+*.spec.ts
+*.e2e-spec.ts
+jest-e2e.json
+
+# Environment files (secrets)
+.env
+.env.*.local
+.env.local
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+*.md
+!README.md
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# CI/CD
+.github/
+
+# Logs
+logs/
+*.log
+
+# Temp files
+.temp/
+.tmp/
+temp/
+tmp/
+
+# Lock files (other package managers)
+pnpm-lock.yaml
+yarn.lock
+
+# Misc
+.eslintcache
+.prettierrc
+eslint.config.mjs

--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 1: Builder
+# ─────────────────────────────────────────────────────────────────────────────
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Install build dependencies for native modules (e.g., bcrypt)
+RUN apk add --no-cache python3 make g++
+
+# Copy package files for layer caching
+COPY package*.json ./
+
+# Install ALL dependencies (including devDependencies needed for nest build)
+RUN npm ci
+
+# Copy source code
+COPY tsconfig.json tsconfig.build.json nest-cli.json ./
+COPY src/ ./src/
+
+# Build the NestJS application
+RUN npm run build
+
+# Prune devDependencies for production
+RUN npm prune --omit=dev
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stage 2: Production Runner
+# ─────────────────────────────────────────────────────────────────────────────
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dumb-init for proper signal handling
+RUN apk add --no-cache dumb-init
+
+# Create non-root user
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nestjs -u 1001
+
+# Copy production node_modules and built dist from builder
+COPY --from=builder --chown=nestjs:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=nestjs:nodejs /app/dist ./dist
+COPY --from=builder --chown=nestjs:nodejs /app/package*.json ./
+
+# Copy configuration files (excluded from build context if not present)
+COPY --chown=nestjs:nodejs nest-cli.json tsconfig*.json ./
+
+# Set NODE_ENV
+ENV NODE_ENV=production
+
+# Expose default NestJS port
+EXPOSE 3000
+
+# Switch to non-root user
+USER nestjs
+
+# Use dumb-init to handle signals properly
+ENTRYPOINT ["dumb-init", "--"]
+
+# Start the application
+CMD ["node", "dist/main"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,49 @@
-version: '3.8'
-
 services:
+  # ── Application Services ─────────────────────────────────────────────────
+  backend:
+    build:
+      context: ./app/backend
+      dockerfile: Dockerfile
+    container_name: gatheraa-backend
+    ports:
+      - "${BACKEND_PORT:-3000}:3000"
+    env_file:
+      - ./app/backend/.env
+    environment:
+      - NODE_ENV=production
+      - REDIS_HOST=redis
+      - DB_HOST=db
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - gatheraa-net
+    restart: unless-stopped
+
+  # ── Database ────────────────────────────────────────────────────────────
+  db:
+    image: postgres:16-alpine
+    container_name: gatheraa-db
+    ports:
+      - "${DB_PORT:-5432}:5432"
+    environment:
+      - POSTGRES_USER=${DB_USER:-postgres}
+      - POSTGRES_PASSWORD=${DB_PASS:-postgres}
+      - POSTGRES_DB=${DB_NAME:-gatherraa}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - gatheraa-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-postgres} -d ${DB_NAME:-gatherraa}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # ── Monitoring & Performance Testing ────────────────────────────────────
   influxdb:
     image: influxdb:1.8
     ports:
@@ -9,11 +52,12 @@ services:
       - INFLUXDB_DB=k6
     networks:
       - k6-net
+      - gatheraa-net
 
   grafana:
     image: grafana/grafana:latest
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -22,14 +66,26 @@ services:
       - ./dashboards:/var/lib/grafana/dashboards
     networks:
       - k6-net
+      - gatheraa-net
 
   redis:
     image: redis:alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
+    command: >
+      sh -c 'redis-server${REDIS_PASSWORD:+ --requirepass "$REDIS_PASSWORD"}'
+    volumes:
+      - redis_data:/data
     networks:
-      - k6-net
+      - gatheraa-net
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:
 
 networks:
   k6-net:
+    driver: bridge
+  gatheraa-net:
     driver: bridge


### PR DESCRIPTION
- Add multi-stage Dockerfile (builder + production runner) in app/backend/
- Add comprehensive .dockerignore to exclude unnecessary build context
- Update docker-compose.yaml to include backend, postgres, and redis services
- Remove deprecated version: '3.8' directive
- Add health checks for database service
- Secure Redis with conditional requirepass
- Add gatheraa-net for application services
- Change Grafana port to 3001 to avoid conflict with backend on 3000

Closes #417