### PR TITLE
feat: add docker-compose.override.yml.example for local development (…

### DIFF
--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,31 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Docker Compose Override (Local Development)
+# ─────────────────────────────────────────────────────────────────────────────
+# Copy this file to docker-compose.override.yml and customize for local dev.
+# The override file is automatically loaded by Docker Compose alongside the
+# base docker-compose.yaml, allowing you to override or extend service configs
+# without modifying the base file.
+#
+# Usage:
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   docker compose up
+#
+# This file should be gitignored — add it to your .gitignore:
+#   echo "docker-compose.override.yml" >> .gitignore
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+  backend:
+    environment:
+      - NODE_ENV=development
+    ports:
+      - "9229:9229"                # Node.js debugger port
+
+  db:
+    ports:
+      - "5432:5432"                # Expose DB directly for local tools
+
+  redis:
+    ports:
+      - "6379:6379"                # Expose Redis directly for local tools
+    command: redis-server          # No password in local dev


### PR DESCRIPTION
…#418)

- Add docker-compose.override.yml.example with common local dev overrides
- Provides template for node debugger port, DB/Redis local access
- Removes Redis password requirement in local development

Closes #418