### PR TITLE
fix: reduce any type usage in critical paths and enable ESLint warning (closes #411)

### DIFF
--- a/app/backend/eslint.config.mjs
+++ b/app/backend/eslint.config.mjs
@@ -29,7 +29,7 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-floating-promises': 'warn',
       '@typescript-eslint/no-unsafe-argument': 'warn',
       "prettier/prettier": ["error", { endOfLine: "auto" }],

--- a/app/backend/src/audit/entities/audit-log.entity.ts
+++ b/app/backend/src/audit/entities/audit-log.entity.ts
@@ -32,14 +32,15 @@ export class AuditLog {
   entityId: string;
 
   @Column({ type: 'simple-json', nullable: true })
-  oldValue: any;
+  oldValue: unknown;
 
   @Column({ type: 'simple-json', nullable: true })
-  newValue: any;
+  newValue: unknown;
 
-  private sanitizeData(data: any): any {
+  private sanitizeData(data: unknown): Record<string, unknown> | null {
     if (!data) return null;
-    const sanitized = { ...data };
+    if (typeof data !== 'object') return null;
+    const sanitized = { ...data as Record<string, unknown> };
     
     // List of sensitive keys to redact from logs
     for (const key of Object.keys(sanitized)) {
@@ -59,7 +60,7 @@ export class AuditLog {
     requestUrl?: string;
     status?: number;
     sessionId?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   };
 
   @Column({ type: 'varchar', length: 64, nullable: true })

--- a/app/backend/src/audit/interceptors/audit.interceptor.ts
+++ b/app/backend/src/audit/interceptors/audit.interceptor.ts
@@ -21,7 +21,7 @@ export class AuditInterceptor implements NestInterceptor {
     private readonly auditService: AuditService,
   ) { }
 
-  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const auditData = this.reflector.get<{ action?: string; entityName?: string }>(
       AUDIT_METADATA_KEY,
       context.getHandler(),
@@ -99,7 +99,7 @@ export class AuditInterceptor implements NestInterceptor {
       case 'GET':
         return AuditAction.ACCESS;
       default:
-        return AuditAction.ACCESS as any as AuditAction;
+        return AuditAction.ACCESS;
     }
   }
 
@@ -108,9 +108,10 @@ export class AuditInterceptor implements NestInterceptor {
     return parts[1] || 'Unknown';
   }
 
-  private sanitizeData(data: any): any {
+  private sanitizeData(data: unknown): Record<string, unknown> | null {
     if (!data) return null;
-    const sanitized = { ...data };
+    if (typeof data !== 'object') return null;
+    const sanitized = { ...data as Record<string, unknown> };
     
     // List of sensitive keys to redact from logs
     const sensitiveKeys = ['password', 'token', 'secret', 'key', 'private', 'nonce'];

--- a/app/backend/src/audit/services/audit.service.ts
+++ b/app/backend/src/audit/services/audit.service.ts
@@ -9,6 +9,16 @@ import { AuditAction } from '../constants/audit.constants';
 import * as crypto from 'node:crypto';
 import { ConfigService } from '@nestjs/config';
 
+export interface AuditEventData {
+  userId?: string;
+  action: AuditAction | string;
+  entityName?: string;
+  entityId?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
 @Injectable()
 export class AuditService {
   private readonly logger = new Logger(AuditService.name);
@@ -27,15 +37,7 @@ export class AuditService {
     this.encryptionKey = Buffer.from(rawKey);
   }
 
-  async logEvent(data: {
-    userId?: string;
-    action: AuditAction | string;
-    entityName?: string;
-    entityId?: string;
-    oldValue?: any;
-    newValue?: any;
-    metadata?: any;
-  }): Promise<AuditLog> {
+  async logEvent(data: AuditEventData): Promise<AuditLog> {
     const auditLog = new AuditLog();
     auditLog.userId = data.userId || 'anonymous';
     auditLog.action = data.action;

--- a/app/backend/src/audit/services/compliance.service.ts
+++ b/app/backend/src/audit/services/compliance.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { AuditService } from './audit.service';
+import type { AuditLog } from '../entities/audit-log.entity';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -45,19 +46,19 @@ export class ComplianceService {
     return filePath;
   }
 
-  private detectAnomalies(logs: any[]) {
+  private detectAnomalies(logs: AuditLog[]) {
     // Simple anomaly detection (e.g., high volume of deletes, out-of-hours access)
     return logs.filter(log => log.action === 'DELETE').length > 100 ? 'High volume of deletions detected' : 'Normal';
   }
 
-  private summarizeActions(logs: any[]) {
+  private summarizeActions(logs: AuditLog[]) {
     return logs.reduce((acc, log) => {
       acc[log.action] = (acc[log.action] || 0) + 1;
       return acc;
     }, {});
   }
 
-  private async verifyLogs(logs: any[]) {
+  private async verifyLogs(logs: AuditLog[]) {
     const results = await Promise.all(logs.slice(0, 100).map(log => this.auditService.verifyLogIntegrity(log.id)));
     const validCount = results.filter(Boolean).length;
     return `Verified ${validCount}/${results.length} samples. Integrity confirmed.`;

--- a/app/backend/src/auth/strategies/siwe.strategy.ts
+++ b/app/backend/src/auth/strategies/siwe.strategy.ts
@@ -2,6 +2,7 @@ import { Strategy } from 'passport-custom';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { SiweMessage } from 'siwe';
+import type { Request } from 'express';
 
 export interface SiweValidateResult {
   address: string;
@@ -14,7 +15,7 @@ export class SiweStrategy extends PassportStrategy(Strategy, 'siwe') {
     super();
   }
 
-  async validate(req: any): Promise<SiweValidateResult> {
+  async validate(req: Request): Promise<SiweValidateResult> {
     const { message, signature } = req.body;
     
     if (!message || !signature) {

--- a/app/backend/src/payments/controllers/payment.controller.ts
+++ b/app/backend/src/payments/controllers/payment.controller.ts
@@ -9,20 +9,18 @@ import {
   Query,
   UseGuards,
   Req,
-  Res,
   HttpCode,
   HttpStatus,
   BadRequestException,
-  NotFoundException,
 } from '@nestjs/common';
-import type { Request, Response } from 'express';
+import type { Request } from 'express';
 import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
-import { Request as ExpressRequest } from 'express';
 import { PaymentService } from '../services/payment.service';
 import { StripeService } from '../services/stripe.service';
 import { CryptoPaymentService } from '../services/crypto-payment.service';
 import { ReconciliationService } from '../services/reconciliation.service';
 import { RateLimit } from '../../rate-limit/rate-limit.decorator';
+import type { User } from '../../users/entities/user.entity';
 import {
   CreatePaymentDto,
   InitiateStripePaymentDto,
@@ -34,6 +32,10 @@ import {
   UpdatePaymentMethodDto,
   PaymentListDto,
 } from '../dto/payment.dto';
+
+interface AuthenticatedRequest extends Request {
+  user: User;
+}
 
 @Controller('payments')
 @UseGuards(JwtAuthGuard)
@@ -50,7 +52,7 @@ export class PaymentController {
    */
   @Post()
   @RateLimit('EXPENSIVE')
-  async createPayment(@Body() dto: CreatePaymentDto, @Req() request: Request): Promise<any> {
+  async createPayment(@Body() dto: CreatePaymentDto, @Req() request: Request): Promise<Record<string, unknown>> {
     const ipAddress = this.getClientIpAddress(request);
     const payment = await this.paymentService.createPayment(dto, ipAddress);
 
@@ -81,7 +83,7 @@ export class PaymentController {
    */
   @Post('stripe/confirm')
   @RateLimit('EXPENSIVE')
-  async confirmStripePayment(@Body() dto: ConfirmStripePaymentDto): Promise<any> {
+  async confirmStripePayment(@Body() dto: ConfirmStripePaymentDto): Promise<Record<string, unknown>> {
     const payment = await this.stripeService.confirmPayment(dto);
 
     return {
@@ -97,7 +99,7 @@ export class PaymentController {
    */
   @Post('crypto/initiate')
   @RateLimit('EXPENSIVE')
-  async initiateCryptoPayment(@Body() dto: InitiateCryptoPaymentDto): Promise<any> {
+  async initiateCryptoPayment(@Body() dto: InitiateCryptoPaymentDto): Promise<Record<string, unknown>> {
     // Validate wallet address
     if (!this.cryptoPaymentService.isValidAddress(dto.fromAddress, dto.method)) {
       throw new BadRequestException('Invalid wallet address');
@@ -125,7 +127,7 @@ export class PaymentController {
    */
   @Post('crypto/verify')
   @RateLimit('API')
-  async verifyCryptoPayment(@Body() dto: VerifyCryptoPaymentDto): Promise<any> {
+  async verifyCryptoPayment(@Body() dto: VerifyCryptoPaymentDto): Promise<Record<string, unknown>> {
     const payment = await this.cryptoPaymentService.verifyTransaction(dto);
 
     return {
@@ -141,7 +143,7 @@ export class PaymentController {
    * Get payment by ID
    */
   @Get(':id')
-  async getPayment(@Param('id') id: string): Promise<any> {
+  async getPayment(@Param('id') id: string): Promise<Record<string, unknown>> {
     const payment = await this.paymentService.getPaymentById(id);
 
     return {
@@ -168,7 +170,7 @@ export class PaymentController {
     @Param('userId') userId: string,
     @Query('limit') limit: number = 20,
     @Query('offset') offset: number = 0,
-  ): Promise<any> {
+  ): Promise<Record<string, unknown>> {
     const [payments, total] = await this.paymentService.getUserPayments(userId, limit, offset);
 
     return {
@@ -194,7 +196,7 @@ export class PaymentController {
   async refundPayment(
     @Param('id') paymentId: string,
     @Body() dto: CreateRefundDto,
-  ): Promise<any> {
+  ): Promise<Record<string, unknown>> {
     const refund = await this.paymentService.refundPayment({
       ...dto,
       paymentId,
@@ -214,7 +216,7 @@ export class PaymentController {
    * Get payment refunds
    */
   @Get(':id/refunds')
-  async getPaymentRefunds(@Param('id') paymentId: string): Promise<any> {
+  async getPaymentRefunds(@Param('id') paymentId: string): Promise<Record<string, unknown>> {
     const refunds = await this.paymentService.getPaymentRefunds(paymentId);
 
     return {
@@ -235,8 +237,8 @@ export class PaymentController {
   @Post('methods/save')
   async savePaymentMethod(
     @Body() dto: SavePaymentMethodDto,
-    @Req() request: any,
-  ): Promise<any> {
+    @Req() request: AuthenticatedRequest,
+  ): Promise<Record<string, unknown>> {
     const userId = request.user.id;
 
     const method = await this.paymentService.savePaymentMethod(
@@ -259,7 +261,7 @@ export class PaymentController {
    * Get saved payment methods
    */
   @Get('methods')
-  async getSavedPaymentMethods(@Req() request: any): Promise<any> {
+  async getSavedPaymentMethods(@Req() request: AuthenticatedRequest): Promise<Record<string, unknown>> {
     const userId = request.user.id;
     const methods = await this.paymentService.getSavedPaymentMethods(userId);
 
@@ -283,8 +285,8 @@ export class PaymentController {
   async updatePaymentMethod(
     @Param('id') id: string,
     @Body() dto: UpdatePaymentMethodDto,
-    @Req() request: any,
-  ): Promise<any> {
+    @Req() request: AuthenticatedRequest,
+  ): Promise<Record<string, unknown>> {
     const userId = request.user.id;
 
     if (dto.isDefault) {
@@ -304,8 +306,8 @@ export class PaymentController {
   @Delete('methods/:id')
   async deletePaymentMethod(
     @Param('id') id: string,
-    @Req() request: any,
-  ): Promise<any> {
+    @Req() request: AuthenticatedRequest,
+  ): Promise<Record<string, unknown>> {
     const userId = request.user.id;
     await this.paymentService.deleteSavedPaymentMethod(userId, id);
 
@@ -319,7 +321,7 @@ export class PaymentController {
   async getAnalytics(
     @Query('dateFrom') dateFrom?: string,
     @Query('dateTo') dateTo?: string,
-  ): Promise<any> {
+  ): Promise<Record<string, unknown>> {
     const from = dateFrom ? new Date(dateFrom) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     const to = dateTo ? new Date(dateTo) : new Date();
 
@@ -330,7 +332,7 @@ export class PaymentController {
    * Get reconciliation reports
    */
   @Get('reconciliation/reports')
-  async getReconciliationReports(@Query('limit') limit: number = 30): Promise<any> {
+  async getReconciliationReports(@Query('limit') limit: number = 30): Promise<Record<string, unknown>> {
     const reports = await this.reconciliationService.getReconciliationReports(limit);
 
     return {
@@ -351,7 +353,7 @@ export class PaymentController {
    * Run reconciliation manually
    */
   @Post('reconciliation/run')
-  async runReconciliation(@Query('provider') provider: string = 'stripe'): Promise<any> {
+  async runReconciliation(@Query('provider') provider: string = 'stripe'): Promise<Record<string, unknown>> {
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
@@ -359,7 +361,7 @@ export class PaymentController {
     const tomorrow = new Date(yesterday);
     tomorrow.setDate(tomorrow.getDate() + 1);
 
-    let result;
+    let result: { id: string; provider: string; status: string; discrepancyCount: number; completedAt: Date };
 
     if (provider === 'stripe') {
       result = await this.reconciliationService.reconcileStripe(yesterday, tomorrow);
@@ -382,7 +384,7 @@ export class PaymentController {
    * Retry a failed payment
    */
   @Post(':id/retry')
-  async retryPayment(@Param('id') id: string): Promise<any> {
+  async retryPayment(@Param('id') id: string): Promise<Record<string, unknown>> {
     const payment = await this.paymentService.retryPayment(id);
 
     return {

--- a/app/backend/src/payments/services/payment.service.ts
+++ b/app/backend/src/payments/services/payment.service.ts
@@ -10,6 +10,10 @@ import { SavedPaymentMethod } from '../entities/saved-payment-method.entity';
 import { CreatePaymentDto, VerifyCryptoPaymentDto, CreateRefundDto } from '../dto/payment.dto';
 import { v4 as uuidv4 } from 'uuid';
 
+export interface PaymentMethodData {
+  stripePaymentMethodId: string;
+}
+
 @Injectable()
 export class PaymentService {
   constructor(
@@ -208,7 +212,7 @@ export class PaymentService {
    */
   async savePaymentMethod(
     userId: string,
-    paymentMethodData: any,
+    paymentMethodData: PaymentMethodData,
     nickname: string,
     setAsDefault?: boolean,
   ): Promise<SavedPaymentMethod> {

--- a/app/backend/src/sessions/sessions.service.ts
+++ b/app/backend/src/sessions/sessions.service.ts
@@ -2,6 +2,16 @@ import { Injectable, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/commo
 import { ConfigService } from '@nestjs/config';
 import { createClient, RedisClientType } from 'redis';
 
+export interface SessionData {
+  userId: string;
+  accessToken?: string;
+  refreshToken?: string;
+  walletAddress?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
 @Injectable()
 export class SessionsService implements OnModuleInit, OnModuleDestroy {
   private redisClient: RedisClientType;
@@ -35,9 +45,9 @@ export class SessionsService implements OnModuleInit, OnModuleDestroy {
     await this.redisClient.quit();
   }
 
-  async createSession(sessionId: string, userId: string, data: any = {}, ttl: number = 86400): Promise<boolean> {
+  async createSession(sessionId: string, userId: string, data: Partial<SessionData> = {}, ttl: number = 86400): Promise<boolean> {
     try {
-      const sessionData = {
+      const sessionData: SessionData = {
         userId,
         ...data,
         createdAt: new Date().toISOString(),
@@ -59,7 +69,7 @@ export class SessionsService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  async getSession(sessionId: string): Promise<any> {
+  async getSession(sessionId: string): Promise<SessionData | null> {
     try {
       const sessionData = await this.redisClient.get(`session:${sessionId}`);
       if (!sessionData) return null;
@@ -71,7 +81,7 @@ export class SessionsService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  async updateSession(sessionId: string, data: any): Promise<boolean> {
+  async updateSession(sessionId: string, data: Partial<SessionData>): Promise<boolean> {
     try {
       const session = await this.getSession(sessionId);
       if (!session) return false;


### PR DESCRIPTION
## Summary

Reduces widespread any type usage in the most critical backend paths (auth, sessions, audit, payments) and enables the ESLint @typescript-eslint/no-explicit-any rule as a warning to prevent future regressions.

## Changes (9 files, +74 / -52)

### ESLint Config
- **eslint.config.mjs**: Changed no-explicit-any from off -> warn

### Sessions Module
- Added SessionData interface with typed fields
- Replaced any params in createSession, getSession, updateSession with Partial<SessionData>

### Audit Module
- Added AuditEventData interface for the logEvent method
- Replaced any with unknown in entity fields (oldValue, newValue, metadata)
- Fixed audit.interceptor.ts: removed as any cast from mapMethodToAction, improved sanitizeData typing
- Fixed compliance.service.ts: uses AuditLog[] instead of unknown[]

### Auth Module
- Fixed siwe.strategy.ts: replaced req: any with req: Request from express

### Payments Module
- Created AuthenticatedRequest interface extending express Request
- Replaced request: any parameters with AuthenticatedRequest
- Replaced Promise<any> return types with Promise<Record<string, unknown>>
- Fixed implicit any in let result variable
- Added PaymentMethodData interface for savePaymentMethod parameter

This is a gradual improvement targeting the most critical paths first.

Closes #411