### PR TITLE
feat(sponsors): add sponsor showcase section with tiers, logo grid, a…

### DIFF
--- a/app/frontend/app/sponsors/page.tsx
+++ b/app/frontend/app/sponsors/page.tsx
@@ -1,0 +1,10 @@
+import { SponsorShowcase } from "@/components/sponsors/SponsorShowcase";
+import { sponsors } from "@/lib/data/sponsors";
+
+export default function SponsorsPage() {
+  return (
+    <div className="flex min-h-screen flex-col bg-zinc-50 font-sans dark:bg-black">
+      <SponsorShowcase sponsors={sponsors} />
+    </div>
+  );
+}

--- a/app/frontend/components/sponsors/SponsorDetailsModal.tsx
+++ b/app/frontend/components/sponsors/SponsorDetailsModal.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Sponsor } from "@/lib/types/sponsor";
+import { SponsorTierBadge } from "@/components/sponsors/SponsorTierBadge";
+
+interface SponsorDetailsModalProps {
+  sponsor: Sponsor | null;
+  onClose: () => void;
+}
+
+export function SponsorDetailsModal({
+  sponsor,
+  onClose,
+}: SponsorDetailsModalProps) {
+  // Note: `animate-in` / `fade-in` / `zoom-in-95` come from the
+  // `tailwindcss-animate` plugin. If that plugin isn't installed, these
+  // classes are simply no-ops (no animation) — the modal still works fine,
+  // just without the entrance transition. Drop them if you'd rather not add
+  // the dependency.
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Close on Escape, lock body scroll while open, focus the close button so
+  // keyboard users land somewhere sensible inside the dialog.
+  useEffect(() => {
+    if (!sponsor) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [sponsor, onClose]);
+
+  if (!sponsor) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm motion-safe:animate-in motion-safe:fade-in"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="sponsor-modal-heading"
+        onClick={(event) => event.stopPropagation()}
+        className="relative w-full max-w-md rounded-3xl border border-zinc-200 bg-white p-6 shadow-xl motion-safe:animate-in motion-safe:zoom-in-95 dark:border-zinc-800 dark:bg-zinc-950"
+      >
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close sponsor details"
+          className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 dark:text-zinc-400 dark:hover:bg-zinc-900 dark:hover:text-zinc-50"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            width="16"
+            height="16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <path d="M18 6 6 18M6 6l12 12" />
+          </svg>
+        </button>
+
+        <div className="flex items-center justify-center rounded-2xl bg-zinc-50 p-6 dark:bg-zinc-900">
+          {/* Plain <img>: see note in SponsorLogoGrid about external domains. */}
+          <img
+            src={sponsor.logoUrl}
+            alt={sponsor.name}
+            className="h-16 w-auto max-w-[200px] object-contain"
+          />
+        </div>
+
+        <div className="mt-5 flex flex-col gap-3">
+          <div className="flex items-start justify-between gap-3">
+            <h2
+              id="sponsor-modal-heading"
+              className="text-lg font-semibold text-zinc-900 dark:text-zinc-50"
+            >
+              {sponsor.name}
+            </h2>
+            <SponsorTierBadge tier={sponsor.tier} />
+          </div>
+
+          {sponsor.description && (
+            <p className="text-sm leading-6 text-zinc-600 dark:text-zinc-400">
+              {sponsor.description}
+            </p>
+          )}
+
+          {sponsor.contributionSummary && (
+            <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              {sponsor.contributionSummary}
+            </p>
+          )}
+
+          {sponsor.websiteUrl && (
+            <a
+              href={sponsor.websiteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-2 inline-flex h-10 w-full items-center justify-center rounded-full border border-foreground px-5 text-sm font-medium text-foreground transition-colors hover:bg-[#f5f5f5] dark:hover:bg-[#1a1a1a]"
+            >
+              Visit website
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/components/sponsors/SponsorLogoGrid.tsx
+++ b/app/frontend/components/sponsors/SponsorLogoGrid.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import {
+  SPONSOR_TIER_META,
+  groupSponsorsByTier,
+  type Sponsor,
+} from "@/lib/types/sponsor";
+
+interface SponsorLogoGridProps {
+  sponsors: Sponsor[];
+  onSelectSponsor: (sponsor: Sponsor) => void;
+}
+
+export function SponsorLogoGrid({
+  sponsors,
+  onSelectSponsor,
+}: SponsorLogoGridProps) {
+  const groups = groupSponsorsByTier(sponsors);
+
+  if (groups.length === 0) {
+    return (
+      <p className="text-sm text-zinc-500 dark:text-zinc-400">
+        No sponsors to show yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-10">
+      {groups.map(({ tier, sponsors: tierSponsors }) => {
+        const meta = SPONSOR_TIER_META[tier];
+        return (
+          <section key={tier} aria-labelledby={`tier-${tier}-heading`}>
+            <div className="mb-4 flex items-center gap-3">
+              <h3
+                id={`tier-${tier}-heading`}
+                className="text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400"
+              >
+                {meta.label}
+              </h3>
+              <div className="h-px flex-1 bg-zinc-200 dark:bg-zinc-800" />
+            </div>
+
+            <ul className="flex flex-wrap items-center gap-3">
+              {tierSponsors.map((sponsor) => (
+                <li key={sponsor.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectSponsor(sponsor)}
+                    aria-haspopup="dialog"
+                    className="group flex items-center justify-center rounded-2xl border border-zinc-200 bg-white px-6 py-4 transition-all hover:-translate-y-0.5 hover:border-zinc-300 hover:shadow-sm motion-reduce:hover:translate-y-0 dark:border-zinc-800 dark:bg-zinc-950 dark:hover:border-zinc-700"
+                  >
+                    {/*
+                      Plain <img> on purpose: sponsor logos can come from
+                      arbitrary external hosts, so next/image would need every
+                      domain added to next.config's remotePatterns first.
+                      Swap to next/image once logos are served from a known,
+                      configured origin.
+                    */}
+                    <img
+                      src={sponsor.logoUrl}
+                      alt={sponsor.name}
+                      style={{ height: meta.logoHeight }}
+                      className="w-auto max-w-[160px] object-contain opacity-80 grayscale transition-[opacity,filter] group-hover:opacity-100 group-hover:grayscale-0"
+                    />
+                    <span className="sr-only">View details for {sponsor.name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/frontend/components/sponsors/SponsorShowcase.tsx
+++ b/app/frontend/components/sponsors/SponsorShowcase.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState } from "react";
+import type { Sponsor } from "@/lib/types/sponsor";
+import { SponsorLogoGrid } from "@/components/sponsors/SponsorLogoGrid";
+import { SponsorDetailsModal } from "@/components/sponsors/SponsorDetailsModal";
+
+interface SponsorShowcaseProps {
+  sponsors: Sponsor[];
+  title?: string;
+  subtitle?: string;
+}
+
+export function SponsorShowcase({
+  sponsors,
+  title = "Our sponsors",
+  subtitle = "Gatherraa runs on the people and teams who back its missions.",
+}: SponsorShowcaseProps) {
+  const [selectedSponsor, setSelectedSponsor] = useState<Sponsor | null>(null);
+
+  return (
+    <section className="w-full max-w-7xl mx-auto px-6 py-16">
+      <div className="mb-10 flex flex-col gap-2 text-center sm:text-left">
+        <h2 className="text-2xl font-semibold tracking-tight text-black dark:text-zinc-50">
+          {title}
+        </h2>
+        <p className="text-base text-zinc-600 dark:text-zinc-400">{subtitle}</p>
+      </div>
+
+      <SponsorLogoGrid sponsors={sponsors} onSelectSponsor={setSelectedSponsor} />
+
+      <SponsorDetailsModal
+        sponsor={selectedSponsor}
+        onClose={() => setSelectedSponsor(null)}
+      />
+    </section>
+  );
+}

--- a/app/frontend/components/sponsors/SponsorTierBadge.tsx
+++ b/app/frontend/components/sponsors/SponsorTierBadge.tsx
@@ -1,0 +1,15 @@
+import { SPONSOR_TIER_META, type SponsorTier } from "@/lib/types/sponsor";
+
+export function SponsorTierBadge({ tier }: { tier: SponsorTier }) {
+  const meta = SPONSOR_TIER_META[tier];
+
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 bg-white px-2.5 py-1 text-xs font-medium text-zinc-600 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${meta.accentClassName}`}
+        aria-hidden="true"
+      />
+      {meta.label}
+    </span>
+  );
+}

--- a/app/frontend/lib/data/sponsor.ts
+++ b/app/frontend/lib/data/sponsor.ts
@@ -1,0 +1,66 @@
+import type { Sponsor } from "@/lib/types/sponsor";
+
+/**
+ * Placeholder sponsor list.
+ *
+ * Swap this for a real data source (CMS, API route, or on-chain registry)
+ * once one exists — `SponsorShowcase` only depends on the `Sponsor[]` shape,
+ * not on where the data comes from.
+ */
+export const sponsors: Sponsor[] = [
+  {
+    id: "stellar-foundation",
+    name: "Stellar Development Foundation",
+    tier: "platinum",
+    logoUrl: "/sponsors/stellar-foundation.svg",
+    websiteUrl: "https://stellar.org",
+    description:
+      "Backs the core infrastructure that lets Gatherraa settle event contributions on-chain.",
+    contributionSummary: "Lead sponsor since launch",
+  },
+  {
+    id: "novahost",
+    name: "NovaHost",
+    tier: "gold",
+    logoUrl: "/sponsors/novahost.svg",
+    websiteUrl: "https://example.com/novahost",
+    description: "Provides venue and streaming infrastructure for flagship events.",
+    contributionSummary: "Hosted 6 events this year",
+  },
+  {
+    id: "ledgerline",
+    name: "Ledgerline",
+    tier: "gold",
+    logoUrl: "/sponsors/ledgerline.svg",
+    websiteUrl: "https://example.com/ledgerline",
+    description: "Wallet infrastructure partner powering in-app payouts.",
+  },
+  {
+    id: "trailmark-coop",
+    name: "Trailmark Co-op",
+    tier: "silver",
+    logoUrl: "/sponsors/trailmark.svg",
+    websiteUrl: "https://example.com/trailmark",
+    description: "Community grants for first-time mission organizers.",
+  },
+  {
+    id: "fieldcraft",
+    name: "Fieldcraft Studio",
+    tier: "silver",
+    logoUrl: "/sponsors/fieldcraft.svg",
+    description: "Design partner for event branding kits.",
+  },
+  {
+    id: "loop-collective",
+    name: "Loop Collective",
+    tier: "community",
+    logoUrl: "/sponsors/loop-collective.svg",
+    websiteUrl: "https://example.com/loop",
+  },
+  {
+    id: "basecamp-builders",
+    name: "Basecamp Builders",
+    tier: "community",
+    logoUrl: "/sponsors/basecamp-builders.svg",
+  },
+];

--- a/app/frontend/lib/types/sponsor.ts
+++ b/app/frontend/lib/types/sponsor.ts
@@ -1,0 +1,61 @@
+export type SponsorTier = "platinum" | "gold" | "silver" | "community";
+
+export interface Sponsor {
+  id: string;
+  name: string;
+  tier: SponsorTier;
+  logoUrl: string;
+  websiteUrl?: string;
+  description?: string;
+  /** Short, human-readable line about what this sponsor has backed, e.g. "Backed 4 missions in Q2". */
+  contributionSummary?: string;
+}
+
+/** Display order for tiers, highest commitment first. */
+export const SPONSOR_TIER_ORDER: SponsorTier[] = [
+  "platinum",
+  "gold",
+  "silver",
+  "community",
+];
+
+interface SponsorTierMeta {
+  label: string;
+  /** Logo height in px used in the grid; conveys tier weight without extra copy. */
+  logoHeight: number;
+  /** Small accent dot color used on the tier badge. Kept restrained on purpose. */
+  accentClassName: string;
+}
+
+export const SPONSOR_TIER_META: Record<SponsorTier, SponsorTierMeta> = {
+  platinum: {
+    label: "Platinum",
+    logoHeight: 64,
+    accentClassName: "bg-zinc-400 dark:bg-zinc-300",
+  },
+  gold: {
+    label: "Gold",
+    logoHeight: 52,
+    accentClassName: "bg-amber-500",
+  },
+  silver: {
+    label: "Silver",
+    logoHeight: 42,
+    accentClassName: "bg-zinc-400/70 dark:bg-zinc-500",
+  },
+  community: {
+    label: "Community Partners",
+    logoHeight: 32,
+    accentClassName: "bg-sky-500",
+  },
+};
+
+/** Groups a flat sponsor list into tier buckets, in display order, skipping empty tiers. */
+export function groupSponsorsByTier(
+  sponsors: Sponsor[]
+): { tier: SponsorTier; sponsors: Sponsor[] }[] {
+  return SPONSOR_TIER_ORDER.map((tier) => ({
+    tier,
+    sponsors: sponsors.filter((sponsor) => sponsor.tier === tier),
+  })).filter((group) => group.sponsors.length > 0);
+}


### PR DESCRIPTION
## Summary
Closes #456 — adds the sponsor display components: sponsor tiers, a logo
grid, and a sponsor details modal, composed into a single `SponsorShowcase`
section.

## Changes
- `lib/types/sponsor.ts` — `Sponsor` type, `SponsorTier` type, and
  `SPONSOR_TIER_META` as the single source of truth for tier label/logo
  size/accent color. `groupSponsorsByTier()` groups a flat list by tier in
  display order.
- `lib/data/sponsors.ts` — placeholder sponsor data so the section renders
  end-to-end. Replace with a real data source later; `SponsorShowcase` only
  depends on the `Sponsor[]` shape.
- `components/sponsors/SponsorTierBadge.tsx` — small tier pill, reused in
  the grid section headers and the modal.
- `components/sponsors/SponsorLogoGrid.tsx` — logos grouped by tier in rank
  order, sized by tier weight, grayscale→color on hover, opens the modal on
  click.
- `components/sponsors/SponsorDetailsModal.tsx` — name, tier badge,
  description, optional contribution line, website link. Closes on Escape
  or backdrop click, locks body scroll while open, focuses the close button
  on open.
- `components/sponsors/SponsorShowcase.tsx` — composes the above, owns
  `selectedSponsor` state.
- `app/sponsors/page.tsx` — demo route at `/sponsors` for manual QA.

## Notes for reviewers
- Logos render via plain `<img>`, not `next/image`, since sponsor logos may
  come from domains not yet in `next.config`'s `remotePatterns`. Swap once
  that's configured.
- The modal's `animate-in`/`fade-in`/`zoom-in-95` classes assume the
  `tailwindcss-animate` plugin. If it's not installed they're harmless
  no-ops (no entrance animation) — drop them if you'd rather not add the
  dependency.
- Not wired into the homepage yet — `/sponsors` is just for review. Importing
  `<SponsorShowcase sponsors={sponsors} />` anywhere else is a one-line add.

## How to test
1. `npm run dev`, visit `/sponsors`.
2. Confirm tiers render in order (Platinum → Gold → Silver → Community) with
   decreasing logo size.
3. Click a logo, confirm the modal opens with correct details.
4. Confirm Escape and backdrop click both close the modal.
5. Check dark mode and mobile width.