### PR TITLE
feat(#481, #483): add OrganizerRolePermissionMatrix and EventReputationScore components

### DIFF
--- a/app/frontend/components/organizers/EventReputationScore.tsx
+++ b/app/frontend/components/organizers/EventReputationScore.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import React, { useState } from 'react';
+import { TrendingUp, TrendingDown, Minus, Star, Info, Award, Users, MessageSquare } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface ReputationMetrics {
+  /** Attendance score (0-100) */
+  attendance: number;
+  /** Feedback score (0-100) */
+  feedback: number;
+  /** Reliability score (0-100) */
+  reliability: number;
+}
+
+export interface EventReputationScoreProps {
+  /** Overall reputation score (0-100) */
+  score: number;
+  /** Breakdown metrics */
+  metrics: ReputationMetrics;
+  /** Previous score for trend calculation */
+  previousScore?: number;
+  /** Whether to show star-based display instead of numeric */
+  starBased?: boolean;
+  /** Additional className */
+  className?: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getScoreColor(score: number): string {
+  if (score >= 80) return 'text-green-600 dark:text-green-400';
+  if (score >= 60) return 'text-yellow-600 dark:text-yellow-400';
+  if (score >= 40) return 'text-orange-600 dark:text-orange-400';
+  return 'text-red-600 dark:text-red-400';
+}
+
+function getScoreBg(score: number): string {
+  if (score >= 80) return 'bg-green-500';
+  if (score >= 60) return 'bg-yellow-500';
+  if (score >= 40) return 'bg-orange-500';
+  return 'bg-red-500';
+}
+
+function getScoreLabel(score: number): string {
+  if (score >= 90) return 'Excellent';
+  if (score >= 80) return 'Very Good';
+  if (score >= 70) return 'Good';
+  if (score >= 60) return 'Fair';
+  if (score >= 50) return 'Average';
+  if (score >= 40) return 'Below Average';
+  if (score >= 20) return 'Poor';
+  return 'Very Poor';
+}
+
+function getStars(score: number): number {
+  return Math.round(score / 20);
+}
+
+function getTrend(current: number, previous?: number): { direction: 'up' | 'down' | 'stable'; diff: number } {
+  if (previous === undefined) return { direction: 'stable', diff: 0 };
+  const diff = current - previous;
+  if (diff > 2) return { direction: 'up', diff };
+  if (diff < -2) return { direction: 'down', diff };
+  return { direction: 'stable', diff };
+}
+
+// ─── Tooltip ─────────────────────────────────────────────────────────────────
+
+function Tooltip({ text }: { text: string }) {
+  const [show, setShow] = useState(false);
+  return (
+    <span className="relative inline-flex ml-1">
+      <button
+        type="button"
+        aria-label={text}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        onFocus={() => setShow(true)}
+        onBlur={() => setShow(false)}
+        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      >
+        <Info className="w-3.5 h-3.5" />
+      </button>
+      {show && (
+        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 text-xs text-white bg-gray-800 dark:bg-gray-700 rounded-lg shadow-lg whitespace-nowrap z-20">
+          {text}
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800 dark:border-t-gray-700" />
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ─── MetricBar ────────────────────────────────────────────────────────────────
+
+interface MetricBarProps {
+  label: string;
+  value: number;
+  icon: React.ComponentType<{ className?: string }>;
+  description: string;
+}
+
+function MetricBar({ label, value, icon: Icon, description }: MetricBarProps) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Icon className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{label}</span>
+          <Tooltip text={description} />
+        </div>
+        <span className={`text-sm font-semibold ${getScoreColor(value)}`}>{value}/100</span>
+      </div>
+      <div className="w-full h-2 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${getScoreBg(value)}`}
+          style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+          role="progressbar"
+          aria-valuenow={value}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${label}: ${value} out of 100`}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── StarDisplay ──────────────────────────────────────────────────────────────
+
+function StarDisplay({ score }: { score: number }) {
+  const stars = getStars(score);
+  return (
+    <div className="flex items-center gap-0.5" role="img" aria-label={`${stars} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Star
+          key={i}
+          className={`w-6 h-6 ${
+            i <= stars
+              ? 'text-yellow-400 fill-yellow-400'
+              : 'text-gray-300 dark:text-gray-600'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+// ─── TrendIndicator ───────────────────────────────────────────────────────────
+
+function TrendIndicator({ current, previous }: { current: number; previous?: number }) {
+  const trend = getTrend(current, previous);
+
+  if (trend.direction === 'stable') {
+    return (
+      <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400">
+        <Minus className="w-4 h-4" />
+        <span className="text-xs font-medium">Stable</span>
+      </div>
+    );
+  }
+
+  const isUp = trend.direction === 'up';
+  return (
+    <div className={`flex items-center gap-1 ${isUp ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
+      {isUp ? <TrendingUp className="w-4 h-4" /> : <TrendingDown className="w-4 h-4" />}
+      <span className="text-xs font-medium">
+        {isUp ? '+' : ''}{trend.diff.toFixed(1)} pts
+      </span>
+    </div>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export function EventReputationScore({
+  score,
+  metrics,
+  previousScore,
+  starBased = false,
+  className = '',
+}: EventReputationScoreProps) {
+  const clampedScore = Math.min(100, Math.max(0, score));
+
+  return (
+    <div className={`bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm p-6 ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Award className={`w-5 h-5 ${getScoreColor(clampedScore)}`} />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Reputation Score
+          </h3>
+        </div>
+        <TrendIndicator current={clampedScore} previous={previousScore} />
+      </div>
+
+      {/* Score Display */}
+      <div className="flex items-center gap-6 mb-6">
+        {starBased ? (
+          <div className="flex flex-col items-center gap-1">
+            <StarDisplay score={clampedScore} />
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {getStars(clampedScore)}/5 stars
+            </span>
+          </div>
+        ) : (
+          <div className="flex items-baseline gap-2">
+            <span className={`text-4xl font-bold ${getScoreColor(clampedScore)}`}>
+              {clampedScore}
+            </span>
+            <span className="text-lg text-gray-400 dark:text-gray-500">/100</span>
+          </div>
+        )}
+        <div className="flex flex-col">
+          <span className={`text-sm font-semibold ${getScoreColor(clampedScore)}`}>
+            {getScoreLabel(clampedScore)}
+          </span>
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            Based on {metrics.attendance + metrics.feedback + metrics.reliability > 0 ? '3 metrics' : 'limited data'}
+          </span>
+        </div>
+      </div>
+
+      {/* Score Ring / Progress */}
+      {!starBased && (
+        <div className="mb-6">
+          <div className="w-full h-3 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-700 ${getScoreBg(clampedScore)}`}
+              style={{ width: `${clampedScore}%` }}
+              role="progressbar"
+              aria-valuenow={clampedScore}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`Reputation score: ${clampedScore} out of 100`}
+            />
+          </div>
+          <div className="flex justify-between mt-1">
+            <span className="text-[10px] text-gray-400">0</span>
+            <span className="text-[10px] text-gray-400">50</span>
+            <span className="text-[10px] text-gray-400">100</span>
+          </div>
+        </div>
+      )}
+
+      {/* Breakdown Metrics */}
+      <div className="space-y-3">
+        <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+          Breakdown
+        </h4>
+        <MetricBar
+          label="Attendance"
+          value={metrics.attendance}
+          icon={Users}
+          description="Based on event attendance rates and consistency"
+        />
+        <MetricBar
+          label="Feedback"
+          value={metrics.feedback}
+          icon={MessageSquare}
+          description="Based on attendee reviews and ratings"
+        />
+        <MetricBar
+          label="Reliability"
+          value={metrics.reliability}
+          icon={Award}
+          description="Based on event completion and cancellation history"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default EventReputationScore;

--- a/app/frontend/components/organizers/OrganizerRolePermissionMatrix.tsx
+++ b/app/frontend/components/organizers/OrganizerRolePermissionMatrix.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+import React, { useState, useCallback } from 'react';
+import { Shield, Users, Eye, ChevronDown, ChevronUp, Check, X, Info } from 'lucide-react';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type OrganizerRole = 'admin' | 'co-organizer' | 'moderator';
+
+export interface Permission {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface RoleDefinition {
+  role: OrganizerRole;
+  label: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+  bgColor: string;
+  permissions: string[]; // permission IDs
+}
+
+// ─── Data ─────────────────────────────────────────────────────────────────────
+
+export const ALL_PERMISSIONS: Permission[] = [
+  { id: 'manage-event', label: 'Manage Event', description: 'Create, edit, and delete event details' },
+  { id: 'manage-tickets', label: 'Manage Tickets', description: 'Create and modify ticket types and pricing' },
+  { id: 'manage-attendees', label: 'Manage Attendees', description: 'View and manage attendee list, check-ins' },
+  { id: 'manage-staff', label: 'Manage Staff', description: 'Invite and remove co-organizers and moderators' },
+  { id: 'manage-payments', label: 'Manage Payments', description: 'Access payment settings and payout information' },
+  { id: 'view-analytics', label: 'View Analytics', description: 'Access event analytics and reports' },
+  { id: 'moderate-content', label: 'Moderate Content', description: 'Review and moderate user-generated content' },
+  { id: 'send-announcements', label: 'Send Announcements', description: 'Send announcements to attendees' },
+  { id: 'manage-sponsors', label: 'Manage Sponsors', description: 'Add and manage sponsor listings' },
+  { id: 'manage-settings', label: 'Manage Settings', description: 'Access event settings and integrations' },
+];
+
+export const ROLE_DEFINITIONS: RoleDefinition[] = [
+  {
+    role: 'admin',
+    label: 'Admin',
+    description: 'Full access to all event management features',
+    icon: Shield,
+    color: 'text-red-600 dark:text-red-400',
+    bgColor: 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800',
+    permissions: ['manage-event', 'manage-tickets', 'manage-attendees', 'manage-staff', 'manage-payments', 'view-analytics', 'moderate-content', 'send-announcements', 'manage-sponsors', 'manage-settings'],
+  },
+  {
+    role: 'co-organizer',
+    label: 'Co-organizer',
+    description: 'Can manage most event aspects except staff and payments',
+    icon: Users,
+    color: 'text-blue-600 dark:text-blue-400',
+    bgColor: 'bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-800',
+    permissions: ['manage-event', 'manage-tickets', 'manage-attendees', 'view-analytics', 'moderate-content', 'send-announcements', 'manage-sponsors', 'manage-settings'],
+  },
+  {
+    role: 'moderator',
+    label: 'Moderator',
+    description: 'Can view content and moderate discussions',
+    icon: Eye,
+    color: 'text-green-600 dark:text-green-400',
+    bgColor: 'bg-green-50 dark:bg-green-950/30 border-green-200 dark:border-green-800',
+    permissions: ['manage-attendees', 'view-analytics', 'moderate-content'],
+  },
+];
+
+// ─── Tooltip ─────────────────────────────────────────────────────────────────
+
+function Tooltip({ text }: { text: string }) {
+  const [show, setShow] = useState(false);
+  return (
+    <span className="relative inline-flex ml-1">
+      <button
+        type="button"
+        aria-label={text}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        onFocus={() => setShow(true)}
+        onBlur={() => setShow(false)}
+        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+      >
+        <Info className="w-3.5 h-3.5" />
+      </button>
+      {show && (
+        <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-800 dark:bg-gray-700 rounded shadow-lg whitespace-nowrap z-10">
+          {text}
+          <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800 dark:border-t-gray-700" />
+        </span>
+      )}
+    </span>
+  );
+}
+
+// ─── PermissionRow ───────────────────────────────────────────────────────────
+
+interface PermissionRowProps {
+  permission: Permission;
+  roles: RoleDefinition[];
+  roleStates: Record<OrganizerRole, boolean>;
+  onToggle: (role: OrganizerRole, permissionId: string) => void;
+  editable: boolean;
+}
+
+function PermissionRow({ permission, roles, roleStates, onToggle, editable }: PermissionRowProps) {
+  return (
+    <tr className="border-b border-gray-100 dark:border-gray-800 hover:bg-gray-50/50 dark:hover:bg-gray-800/30">
+      <td className="py-3 px-4 text-sm text-gray-700 dark:text-gray-300">
+        <div className="flex items-center">
+          {permission.label}
+          <Tooltip text={permission.description} />
+        </div>
+      </td>
+      {roles.map((roleDef) => {
+        const hasPermission = roleDef.permissions.includes(permission.id);
+        const isChecked = roleStates[roleDef.role] !== undefined
+          ? roleStates[roleDef.role] && hasPermission
+          : hasPermission;
+        return (
+          <td key={roleDef.role} className="py-3 px-4 text-center">
+            {editable ? (
+              <button
+                type="button"
+                role="checkbox"
+                aria-checked={isChecked}
+                aria-label={`${permission.label} for ${roleDef.label}`}
+                onClick={() => onToggle(roleDef.role, permission.id)}
+                className={`w-5 h-5 rounded border-2 flex items-center justify-center transition-all ${
+                  isChecked
+                    ? 'bg-blue-600 border-blue-600 text-white'
+                    : 'border-gray-300 dark:border-gray-600 hover:border-blue-400'
+                }`}
+              >
+                {isChecked && <Check className="w-3 h-3" />}
+              </button>
+            ) : isChecked ? (
+              <Check className="w-5 h-5 text-green-600 dark:text-green-400 mx-auto" />
+            ) : (
+              <X className="w-5 h-5 text-gray-300 dark:text-gray-600 mx-auto" />
+            )}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+// ─── RoleHierarchy ───────────────────────────────────────────────────────────
+
+function RoleHierarchy({ roles }: { roles: RoleDefinition[] }) {
+  return (
+    <div className="flex items-center justify-center gap-2 py-4">
+      {roles.map((roleDef, idx) => {
+        const Icon = roleDef.icon;
+        return (
+          <React.Fragment key={roleDef.role}>
+            <div className={`flex flex-col items-center gap-1 px-4 py-3 rounded-lg border-2 ${roleDef.bgColor}`}>
+              <Icon className={`w-6 h-6 ${roleDef.color}`} />
+              <span className={`text-sm font-semibold ${roleDef.color}`}>{roleDef.label}</span>
+              <span className="text-xs text-gray-500 dark:text-gray-400 text-center max-w-[120px]">
+                {roleDef.permissions.length} permissions
+              </span>
+            </div>
+            {idx < roles.length - 1 && (
+              <div className="flex flex-col items-center text-gray-400">
+                <ChevronDown className="w-4 h-4 rotate-[-90deg]" />
+                <span className="text-[10px] mt-1">less access</span>
+              </div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Main Component ──────────────────────────────────────────────────────────
+
+export interface OrganizerRolePermissionMatrixProps {
+  /** Initial permission overrides (role → permission ID → boolean) */
+  initialOverrides?: Record<OrganizerRole, Record<string, boolean>>;
+  /** Callback when permissions change */
+  onChange?: (role: OrganizerRole, permissionId: string, value: boolean) => void;
+  /** Whether the matrix is editable */
+  editable?: boolean;
+  /** Additional className */
+  className?: string;
+}
+
+export function OrganizerRolePermissionMatrix({
+  initialOverrides,
+  onChange,
+  editable = false,
+  className = '',
+}: OrganizerRolePermissionMatrixProps) {
+  const [roleStates, setRoleStates] = useState<Record<OrganizerRole, boolean>>(() => {
+    const states: Record<string, boolean> = {};
+    ROLE_DEFINITIONS.forEach((r) => {
+      states[r.role] = true;
+    });
+    return states as Record<OrganizerRole, boolean>;
+  });
+  const [expanded, setExpanded] = useState(true);
+
+  const handleToggle = useCallback(
+    (role: OrganizerRole, permissionId: string) => {
+      setRoleStates((prev) => {
+        const newState = { ...prev, [role]: !prev[role] };
+        return newState;
+      });
+      onChange?.(role, permissionId, !roleStates[role]);
+    },
+    [onChange, roleStates]
+  );
+
+  return (
+    <div className={`bg-white dark:bg-gray-900 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm ${className}`}>
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Organizer Roles & Permissions
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            Manage what each role can do for your event
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          aria-expanded={expanded}
+          className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+        >
+          {expanded ? (
+            <ChevronUp className="w-5 h-5 text-gray-500" />
+          ) : (
+            <ChevronDown className="w-5 h-5 text-gray-500" />
+          )}
+        </button>
+      </div>
+
+      {expanded && (
+        <>
+          {/* Role Hierarchy Visualization */}
+          <div className="px-6 pt-4 pb-2">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+              Role Hierarchy
+            </h3>
+            <RoleHierarchy roles={ROLE_DEFINITIONS} />
+          </div>
+
+          {/* Permission Matrix */}
+          <div className="px-6 pb-6 pt-2 overflow-x-auto">
+            <h3 className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
+              Permission Matrix
+            </h3>
+            <table className="w-full min-w-[500px]">
+              <thead>
+                <tr className="border-b-2 border-gray-200 dark:border-gray-700">
+                  <th className="text-left py-2 px-4 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Permission
+                  </th>
+                  {ROLE_DEFINITIONS.map((roleDef) => (
+                    <th key={roleDef.role} className="text-center py-2 px-4 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                      <span className={roleDef.color}>{roleDef.label}</span>
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {ALL_PERMISSIONS.map((perm) => (
+                  <PermissionRow
+                    key={perm.id}
+                    permission={perm}
+                    roles={ROLE_DEFINITIONS}
+                    roleStates={roleStates}
+                    onToggle={handleToggle}
+                    editable={editable}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default OrganizerRolePermissionMatrix;


### PR DESCRIPTION
## Summary
Adds two new organizer-related frontend components:

### OrganizerRolePermissionMatrix (#481)
- Role hierarchy visualization (Admin → Co-organizer → Moderator)
- Permission checklist matrix with 10 permissions across 3 roles
- Editable toggle view with checkbox controls
- Visual role cards with icons and permission counts
- Accessible tooltips for each permission description

### EventReputationScore (#483)
- Reputation score display (0-100 numeric or 1-5 star-based)
- Breakdown metrics: Attendance, Feedback, Reliability (each 0-100)
- Trend indicator (up/down/stable) with point difference
- Tooltip explanation system for each metric
- Color-coded progress bars and score labels
- ARIA attributes for accessibility

## Files modified
- `app/frontend/components/organizers/OrganizerRolePermissionMatrix.tsx` (new)
- `app/frontend/components/organizers/EventReputationScore.tsx` (new)

Closes #481
Closes #483