### PR TITLE
feat(#478): implementation

### DIFF
--- a/app/frontend/components/credentials/CredentialCard.tsx
+++ b/app/frontend/components/credentials/CredentialCard.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Shield, CheckCircle, XCircle, Clock, ExternalLink } from 'lucide-react';
+import { Badge } from '@/components/ui';
+
+export type CredentialType = 'email' | 'wallet' | 'kyc' | 'phone' | 'social' | 'custom';
+export type VerificationStatus = 'verified' | 'pending' | 'revoked' | 'expired';
+
+export interface DIDCredential {
+  id: string;
+  type: CredentialType;
+  issuer: string;
+  issuerUrl?: string;
+  verifiedAt: string;
+  expiresAt?: string;
+  status: VerificationStatus;
+  details?: string;
+}
+
+export interface CredentialCardProps {
+  credential: DIDCredential;
+  className?: string;
+}
+
+const credentialTypeLabels: Record<CredentialType, string> = {
+  email: 'Email Verified',
+  wallet: 'Wallet Ownership',
+  kyc: 'KYC Proof',
+  phone: 'Phone Verified',
+  social: 'Social Identity',
+  custom: 'Custom Credential',
+};
+
+const credentialTypeIcons: Record<CredentialType, string> = {
+  email: '📧',
+  wallet: '👛',
+  kyc: '🪪',
+  phone: '📱',
+  social: '👤',
+  custom: '🔖',
+};
+
+function StatusBadge({ status }: { status: VerificationStatus }) {
+  switch (status) {
+    case 'verified':
+      return (
+        <Badge variant="success" className="flex items-center gap-1">
+          <CheckCircle className="h-3 w-3" />
+          Verified
+        </Badge>
+      );
+    case 'pending':
+      return (
+        <Badge variant="warning" className="flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          Pending
+        </Badge>
+      );
+    case 'revoked':
+      return (
+        <Badge variant="destructive" className="flex items-center gap-1">
+          <XCircle className="h-3 w-3" />
+          Revoked
+        </Badge>
+      );
+    case 'expired':
+      return (
+        <Badge variant="secondary" className="flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          Expired
+        </Badge>
+      );
+  }
+}
+
+export function CredentialCard({ credential, className = '' }: CredentialCardProps) {
+  const isRevoked = credential.status === 'revoked';
+  const isExpired = credential.status === 'expired';
+
+  return (
+    <motion.div
+      className={`rounded-lg border bg-white p-4 shadow-sm transition-all ${
+        isRevoked
+          ? 'border-red-200 bg-red-50/50'
+          : isExpired
+          ? 'border-gray-200 bg-gray-50/50'
+          : 'border-gray-200 hover:shadow-md'
+      } ${className}`}
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      {/* Header */}
+      <div className="mb-3 flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-100 text-lg">
+            {credentialTypeIcons[credential.type]}
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-gray-900">
+              {credentialTypeLabels[credential.type]}
+            </h3>
+            <p className="text-xs text-gray-500">ID: {credential.id.slice(0, 12)}...</p>
+          </div>
+        </div>
+        <StatusBadge status={credential.status} />
+      </div>
+
+      {/* Issuer */}
+      <div className="mb-2 flex items-center gap-2">
+        <Shield className="h-4 w-4 text-gray-400" />
+        <span className="text-sm text-gray-600">Issued by:</span>
+        <span className="text-sm font-medium text-gray-800">{credential.issuer}</span>
+        {credential.issuerUrl && (
+          <a
+            href={credential.issuerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:text-blue-700"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        )}
+      </div>
+
+      {/* Timestamps */}
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500">
+        <span>
+          Verified: {new Date(credential.verifiedAt).toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          })}
+        </span>
+        {credential.expiresAt && (
+          <span>
+            Expires: {new Date(credential.expiresAt).toLocaleDateString('en-US', {
+              year: 'numeric',
+              month: 'short',
+              day: 'numeric',
+            })}
+          </span>
+        )}
+      </div>
+
+      {/* Details */}
+      {credential.details && (
+        <p className="mt-2 text-xs text-gray-500">{credential.details}</p>
+      )}
+
+      {/* Revocation warning */}
+      {isRevoked && (
+        <div className="mt-3 flex items-center gap-2 rounded-md bg-red-100 px-3 py-2 text-xs text-red-700">
+          <XCircle className="h-4 w-4" />
+          This credential has been revoked by the issuer.
+        </div>
+      )}
+    </motion.div>
+  );
+}
+
+export default CredentialCard;

--- a/app/frontend/components/credentials/__tests__/CredentialCard.test.tsx
+++ b/app/frontend/components/credentials/__tests__/CredentialCard.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CredentialCard, type DIDCredential } from '@/components/credentials/CredentialCard';
+
+const mockCredential: DIDCredential = {
+  id: 'did:example:1234567890abcdef',
+  type: 'email',
+  issuer: 'Gatherraa Identity',
+  verifiedAt: '2026-06-15T10:30:00Z',
+  status: 'verified',
+  details: 'Primary email credential',
+};
+
+describe('CredentialCard', () => {
+  it('renders credential type and issuer', () => {
+    render(<CredentialCard credential={mockCredential} />);
+    expect(screen.getByText('Email Verified')).toBeInTheDocument();
+    expect(screen.getByText('Gatherraa Identity')).toBeInTheDocument();
+  });
+
+  it('shows verified badge for verified credentials', () => {
+    render(<CredentialCard credential={mockCredential} />);
+    expect(screen.getByText('Verified')).toBeInTheDocument();
+  });
+
+  it('shows revoked badge for revoked credentials', () => {
+    render(<CredentialCard credential={{ ...mockCredential, status: 'revoked' }} />);
+    expect(screen.getByText('Revoked')).toBeInTheDocument();
+    expect(screen.getByText(/revoked by the issuer/i)).toBeInTheDocument();
+  });
+
+  it('shows pending badge for pending credentials', () => {
+    render(<CredentialCard credential={{ ...mockCredential, status: 'pending' }} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+  });
+
+  it('shows expired badge for expired credentials', () => {
+    render(<CredentialCard credential={{ ...mockCredential, status: 'expired' }} />);
+    expect(screen.getByText('Expired')).toBeInTheDocument();
+  });
+
+  it('renders wallet credential type', () => {
+    render(<CredentialCard credential={{ ...mockCredential, type: 'wallet' }} />);
+    expect(screen.getByText('Wallet Ownership')).toBeInTheDocument();
+  });
+
+  it('renders KYC credential type', () => {
+    render(<CredentialCard credential={{ ...mockCredential, type: 'kyc' }} />);
+    expect(screen.getByText('KYC Proof')).toBeInTheDocument();
+  });
+
+  it('displays verification date', () => {
+    render(<CredentialCard credential={mockCredential} />);
+    expect(screen.getByText(/Jun 15, 2026/)).toBeInTheDocument();
+  });
+
+  it('displays expiration date when provided', () => {
+    render(<CredentialCard credential={{ ...mockCredential, expiresAt: '2027-06-15T10:30:00Z' }} />);
+    expect(screen.getByText(/Expires: Jun 15, 2027/)).toBeInTheDocument();
+  });
+
+  it('shows issuer link when issuerUrl is provided', () => {
+    render(<CredentialCard credential={{ ...mockCredential, issuerUrl: 'https://gatherraa.com' }} />);
+    const link = screen.getByTitle('View on explorer');
+    expect(link).toHaveAttribute('href', 'https://gatherraa.com');
+  });
+});


### PR DESCRIPTION
## Summary
Adds `CredentialCard` component for displaying decentralized identity (DID) credentials.

## Changes
- New component: `app/frontend/components/credentials/CredentialCard.tsx`
- New tests: `app/frontend/components/credentials/__tests__/CredentialCard.test.tsx` (10 tests)

## Features
- Displays credential type (email/wallet/KYC/phone/social/custom) with icons
- Verified identity badge with status indicators (verified/pending/revoked/expired)
- Issuer information with optional external link
- Verification timestamp and expiration date display
- Revocation state with visual warning banner
- Animated card entrance with framer-motion

Closes #478