### PR TITLE
Feat/wallet event access gate

### DIFF
--- a/app/frontend/components/ui/molecules/EventAccessGate/EventAccessGate.tsx
+++ b/app/frontend/components/ui/molecules/EventAccessGate/EventAccessGate.tsx
@@ -1,31 +1,40 @@
 'use client';
 
-import React from 'react';
-import { Lock } from 'lucide-react';
+import React, { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Loader2, ShieldAlert, Wallet } from 'lucide-react';
+import { useWalletContext } from '@/lib/wallet/WalletContext';
+import { ConnectWalletModal } from '@/components/wallet/ConnectWalletModal';
 
 export type EventAccessLevel = 'public' | 'registered' | 'organizer';
+export type EventRole = 'guest' | 'attendee' | 'organizer';
 
 export interface EventViewerStatus {
   isAuthenticated: boolean;
   isRegistered: boolean;
   isOrganizer: boolean;
+  role?: EventRole;
 }
 
 export interface EventAccessGateProps {
-  /** Required access level(s) for this UI section. */
+  /** Required access level(s) for this UI section */
   requiredAccess: EventAccessLevel | EventAccessLevel[];
-  /** Current viewer status for this event. */
+  /** Current viewer status for this event */
   viewerStatus: EventViewerStatus;
-  /** Content to render when access is granted. */
+  /** Content to render when access is granted */
   children: React.ReactNode;
-  /** Optional custom fallback when unauthorized. */
+  /** Optional custom fallback when unauthorized */
   fallback?: React.ReactNode;
-  /** Optional message for default fallback. */
+  /** Optional message for default fallback */
   unauthorizedMessage?: string;
-  /** Optional description for default fallback. */
+  /** Optional description for default fallback */
   unauthorizedDescription?: string;
-  /** Optional className for wrapper. */
+  /** Optional className for wrapper */
   className?: string;
+  /** Loading state while access is being resolved */
+  loading?: boolean;
+  /** Redirect destination for the fallback link */
+  redirectTo?: string;
 }
 
 export function hasEventAccess(
@@ -48,13 +57,12 @@ export function hasEventAccess(
   });
 }
 
-function getDefaultAccessLabel(requiredAccess: EventAccessLevel | EventAccessLevel[]): string {
+function getAccessLabel(requiredAccess: EventAccessLevel | EventAccessLevel[]): string {
   const required = Array.isArray(requiredAccess) ? requiredAccess : [requiredAccess];
 
-  if (required.includes('public')) return 'Public';
   if (required.includes('organizer')) return 'Organizer';
-  if (required.includes('registered')) return 'Registered attendee';
-  return 'Restricted';
+  if (required.includes('registered')) return 'Attendee';
+  return 'Public';
 }
 
 export function EventAccessGate({
@@ -65,8 +73,33 @@ export function EventAccessGate({
   unauthorizedMessage,
   unauthorizedDescription,
   className = '',
+  loading = false,
+  redirectTo = '/events',
 }: EventAccessGateProps) {
-  const allowed = hasEventAccess(requiredAccess, viewerStatus);
+  const wallet = useWalletContext();
+  const [isConnectModalOpen, setIsConnectModalOpen] = useState(false);
+
+  const allowed = useMemo(
+    () => hasEventAccess(requiredAccess, viewerStatus),
+    [requiredAccess, viewerStatus]
+  );
+
+  const needsWallet = !viewerStatus.isAuthenticated;
+
+  if (loading || wallet.status === 'connecting') {
+    return (
+      <div
+        className={`rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900 ${className}`.trim()}
+        role="status"
+        aria-live="polite"
+      >
+        <div className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          <span>Checking event access…</span>
+        </div>
+      </div>
+    );
+  }
 
   if (allowed) {
     return <div className={className}>{children}</div>;
@@ -76,27 +109,63 @@ export function EventAccessGate({
     return <div className={className}>{fallback}</div>;
   }
 
-  const accessLabel = getDefaultAccessLabel(requiredAccess);
-
   return (
-    <div
-      className={`rounded-lg border border-amber-200 bg-amber-50/70 p-4 text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-200 ${className}`.trim()}
-      role="note"
-      aria-live="polite"
-    >
-      <div className="flex items-start gap-3">
-        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-200/70 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
-          <Lock className="h-4 w-4" aria-hidden />
-        </span>
-        <div>
-          <p className="text-sm font-semibold">
-            {unauthorizedMessage || 'You do not currently have access to this section.'}
-          </p>
-          <p className="mt-1 text-xs opacity-90">
-            {unauthorizedDescription || `Required access level: ${accessLabel}.`}
-          </p>
+    <>
+      <ConnectWalletModal
+        isOpen={isConnectModalOpen}
+        onClose={() => setIsConnectModalOpen(false)}
+      />
+
+      <div
+        className={`rounded-lg border border-amber-200 bg-amber-50/70 p-4 text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/20 dark:text-amber-200 ${className}`.trim()}
+        role="note"
+        aria-live="polite"
+      >
+        <div className="flex items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-200/70 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+            {needsWallet ? (
+              <Wallet className="h-4 w-4" aria-hidden />
+            ) : (
+              <ShieldAlert className="h-4 w-4" aria-hidden />
+            )}
+          </span>
+
+          <div className="flex-1">
+            <p className="text-sm font-semibold">
+              {unauthorizedMessage ||
+                (needsWallet
+                  ? 'Connect your wallet to access this event content.'
+                  : 'Access denied')}
+            </p>
+
+            <p className="mt-1 text-xs opacity-90">
+              {unauthorizedDescription ||
+                (needsWallet
+                  ? 'This event section is gated by wallet authentication.'
+                  : `Required role: ${getAccessLabel(requiredAccess)}.`)}
+            </p>
+
+            <div className="mt-3 flex flex-wrap gap-3">
+              {needsWallet && (
+                <button
+                  type="button"
+                  onClick={() => setIsConnectModalOpen(true)}
+                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                >
+                  Connect wallet
+                </button>
+              )}
+
+              <Link
+                href={redirectTo}
+                className="rounded-md border border-amber-300 px-3 py-2 text-sm font-medium transition-colors hover:bg-amber-100 dark:border-amber-800 dark:hover:bg-amber-900/30"
+              >
+                Back to events
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/app/frontend/components/ui/molecules/EventAccessGate/EventAccessGate.tsx
+++ b/app/frontend/components/ui/molecules/EventAccessGate/EventAccessGate.tsx
@@ -2,7 +2,7 @@
 
 import React, { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Loader2, ShieldAlert, Wallet } from 'lucide-react';
+import { Loader2, Lock, ShieldAlert, Wallet } from 'lucide-react';
 import { useWalletContext } from '@/lib/wallet/WalletContext';
 import { ConnectWalletModal } from '@/components/wallet/ConnectWalletModal';
 
@@ -17,23 +17,31 @@ export interface EventViewerStatus {
 }
 
 export interface EventAccessGateProps {
-  /** Required access level(s) for this UI section */
+  /** Required access level(s) for this UI section. */
   requiredAccess: EventAccessLevel | EventAccessLevel[];
-  /** Current viewer status for this event */
+
+  /** Current viewer status for this event. */
   viewerStatus: EventViewerStatus;
-  /** Content to render when access is granted */
+
+  /** Content to render when access is granted. */
   children: React.ReactNode;
-  /** Optional custom fallback when unauthorized */
+
+  /** Optional custom fallback when unauthorized. */
   fallback?: React.ReactNode;
-  /** Optional message for default fallback */
+
+  /** Optional message for default fallback. */
   unauthorizedMessage?: string;
-  /** Optional description for default fallback */
+
+  /** Optional description for default fallback. */
   unauthorizedDescription?: string;
-  /** Optional className for wrapper */
+
+  /** Optional className for wrapper. */
   className?: string;
-  /** Loading state while access is being resolved */
+
+  /** Loading state while access is being resolved. */
   loading?: boolean;
-  /** Redirect destination for the fallback link */
+
+  /** Redirect destination shown in fallback UI. */
   redirectTo?: string;
 }
 
@@ -57,11 +65,11 @@ export function hasEventAccess(
   });
 }
 
-function getAccessLabel(requiredAccess: EventAccessLevel | EventAccessLevel[]): string {
+function getDefaultAccessLabel(requiredAccess: EventAccessLevel | EventAccessLevel[]): string {
   const required = Array.isArray(requiredAccess) ? requiredAccess : [requiredAccess];
 
   if (required.includes('organizer')) return 'Organizer';
-  if (required.includes('registered')) return 'Attendee';
+  if (required.includes('registered')) return 'Registered attendee';
   return 'Public';
 }
 
@@ -85,6 +93,7 @@ export function EventAccessGate({
   );
 
   const needsWallet = !viewerStatus.isAuthenticated;
+  const accessLabel = getDefaultAccessLabel(requiredAccess);
 
   if (loading || wallet.status === 'connecting') {
     return (
@@ -102,11 +111,11 @@ export function EventAccessGate({
   }
 
   if (allowed) {
-    return <div className={className}>{children}</div>;
+    return <>{children}</>;
   }
 
   if (fallback) {
-    return <div className={className}>{fallback}</div>;
+    return <>{fallback}</>;
   }
 
   return (
@@ -142,18 +151,24 @@ export function EventAccessGate({
               {unauthorizedDescription ||
                 (needsWallet
                   ? 'This event section is gated by wallet authentication.'
-                  : `Required role: ${getAccessLabel(requiredAccess)}.`)}
+                  : `Required access level: ${accessLabel}.`)}
             </p>
 
             <div className="mt-3 flex flex-wrap gap-3">
-              {needsWallet && (
+              {needsWallet ? (
                 <button
                   type="button"
                   onClick={() => setIsConnectModalOpen(true)}
-                  className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+                  className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
                 >
+                  <Wallet className="h-4 w-4" aria-hidden />
                   Connect wallet
                 </button>
+              ) : (
+                <div className="inline-flex items-center gap-2 rounded-md border border-amber-300 px-3 py-2 text-sm font-medium dark:border-amber-800">
+                  <Lock className="h-4 w-4" aria-hidden />
+                  Access restricted
+                </div>
               )}
 
               <Link


### PR DESCRIPTION
closes  #476 

# Wallet-Based Event Access Gate (#476)

## Summary
Implements a wallet-aware event access gate for event pages and gated event sections.

This update enhances the existing `EventAccessGate` component to support:
- wallet connection checks
- attendee/organizer role-based access
- loading and fallback states
- explicit access denied UI
- connect-wallet CTA and redirect fallback

## What changed

### Updated
- `app/frontend/components/ui/molecules/EventAccessGate/EventAccessGate.tsx`

### Added behavior
- Detects whether the current viewer is wallet-authenticated
- Blocks gated event content when no wallet is connected
- Shows a **Connect wallet** CTA that opens the existing `ConnectWalletModal`
- Supports role/access checks for:
  - `public`
  - `registered` (attendee)
  - `organizer`
- Shows loading UI while access is being resolved
- Shows “Access denied” state for connected wallets without the required role/access
- Supports a configurable `redirectTo` fallback link

## Access model

### Supported access levels
- `public`
- `registered`
- `organizer`

### Viewer status fields
The gate uses:
- `isAuthenticated`
- `isRegistered`
- `isOrganizer`

### Access rules
- `public` → everyone
- `registered` → registered attendee or organizer
- `organizer` → organizer only

## UX behavior
- **Wallet not connected**
  - Renders gated fallback
  - Shows “Connect wallet” CTA
  - Opens `ConnectWalletModal`
- **Wallet connected but unauthorized**
  - Renders “Access denied” UI
- **Access resolving**
  - Renders loading state

## Example usage

```tsx
<EventAccessGate
  requiredAccess={['registered', 'organizer']}
  viewerStatus={viewerStatus}
  unauthorizedMessage="Only registered attendees can submit reviews."
  unauthorizedDescription="Register for this event to unlock the review form."
>
  <ReviewForm />
</EventAccessGate>