### PR TITLE
fix: add CSRF double-submit protection

### DIFF
--- a/app/backend/src/main.ts
+++ b/app/backend/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { configureAppSecurity } from './security/app-security';
 
 // import { ValidationPipe, VersioningType } from '@nestjs/common';
 // import { NestExpressApplication } from '@nestjs/platform-express';
@@ -13,6 +14,7 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  configureAppSecurity(app);
 
   // app.enableVersioning({...});
 
@@ -70,16 +72,6 @@ async function bootstrap() {
   //   prefix: '/uploads/',
   // });
 
-  // app.enableCors({
-  //   origin:
-  //     process.env.NODE_ENV === 'production'
-  //       ? ['https://yourdomain.com']
-  //       : ['http://localhost:3000', 'http://localhost:3001'],
-  //   credentials: true,
-  //   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  //   allowedHeaders: ['Content-Type', 'Authorization', 'X-API-Version'],
-  // });
-
   // app.useGlobalPipes(
   //   new ValidationPipe({
   //     whitelist: true,
@@ -93,4 +85,4 @@ async function bootstrap() {
 
 // initSentry();
 
-bootstrap();
+void bootstrap();

--- a/app/backend/src/security/app-security.ts
+++ b/app/backend/src/security/app-security.ts
@@ -1,0 +1,22 @@
+import type { INestApplication } from '@nestjs/common';
+import { csrfDoubleSubmitMiddleware } from './csrf.middleware';
+
+export function configureAppSecurity(app: INestApplication) {
+  app.enableCors({
+    origin:
+      process.env.NODE_ENV === 'production'
+        ? [process.env.FRONTEND_URL || 'https://yourdomain.com']
+        : ['http://localhost:3000', 'http://localhost:3001'],
+    credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: [
+      'Content-Type',
+      'Authorization',
+      'X-API-Version',
+      'X-CSRF-Token',
+      'X-XSRF-Token',
+    ],
+  });
+
+  app.use(csrfDoubleSubmitMiddleware);
+}

--- a/app/backend/src/security/csrf.middleware.ts
+++ b/app/backend/src/security/csrf.middleware.ts
@@ -1,0 +1,89 @@
+import { ForbiddenException } from '@nestjs/common';
+import type { NextFunction, Request, Response } from 'express';
+import { randomBytes, timingSafeEqual } from 'crypto';
+
+const CSRF_COOKIE_NAME = 'csrf_token';
+const CSRF_HEADER_NAMES = ['x-csrf-token', 'x-xsrf-token'];
+const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+function parseCookieHeader(cookieHeader: string | undefined): Record<string, string> {
+  if (!cookieHeader) {
+    return {};
+  }
+
+  return cookieHeader.split(';').reduce<Record<string, string>>((cookies, entry) => {
+    const [rawName, ...rawValueParts] = entry.trim().split('=');
+    if (!rawName) {
+      return cookies;
+    }
+
+    try {
+      cookies[rawName] = decodeURIComponent(rawValueParts.join('='));
+    } catch {
+      cookies[rawName] = rawValueParts.join('=');
+    }
+    return cookies;
+  }, {});
+}
+
+function getHeaderValue(req: Request): string | undefined {
+  for (const headerName of CSRF_HEADER_NAMES) {
+    const value = req.headers[headerName];
+    if (Array.isArray(value)) {
+      return value[0];
+    }
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function tokensMatch(cookieToken: string, headerToken: string): boolean {
+  const cookieBuffer = Buffer.from(cookieToken);
+  const headerBuffer = Buffer.from(headerToken);
+
+  return cookieBuffer.length === headerBuffer.length && timingSafeEqual(cookieBuffer, headerBuffer);
+}
+
+function getCookieOptions() {
+  return {
+    httpOnly: false,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict' as const,
+    path: '/',
+  };
+}
+
+export function csrfDoubleSubmitMiddleware(req: Request, res: Response, next: NextFunction) {
+  const requestCookies = (req.cookies ?? {}) as Record<string, string>;
+  const cookies = {
+    ...parseCookieHeader(req.headers.cookie),
+    ...requestCookies,
+  };
+  const csrfCookie = cookies[CSRF_COOKIE_NAME];
+
+  if (SAFE_METHODS.has(req.method)) {
+    if (!csrfCookie) {
+      res.cookie(CSRF_COOKIE_NAME, randomBytes(32).toString('hex'), getCookieOptions());
+    }
+
+    next();
+    return;
+  }
+
+  const hasCookieCredentials = Boolean(req.headers.cookie);
+  if (!hasCookieCredentials) {
+    next();
+    return;
+  }
+
+  const csrfHeader = getHeaderValue(req);
+  if (!csrfCookie || !csrfHeader || !tokensMatch(csrfCookie, csrfHeader)) {
+    next(new ForbiddenException('Invalid CSRF token'));
+    return;
+  }
+
+  next();
+}

--- a/app/backend/test/app.e2e-spec.ts
+++ b/app/backend/test/app.e2e-spec.ts
@@ -3,6 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { configureAppSecurity } from './../src/security/app-security';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication<App>;
@@ -13,13 +14,34 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    configureAppSecurity(app);
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    return request(app.getHttpServer()).get('/').expect(200).expect('Hello World!');
+  });
+
+  it('rejects cross-origin state-changing cookie requests without matching CSRF header', async () => {
+    await request(app.getHttpServer())
+      .post('/')
+      .set('Origin', 'http://localhost:3001')
+      .set('Cookie', ['access_token=session-cookie; csrf_token=trusted-token'])
+      .send({ state: 'change' })
+      .expect(403);
+  });
+
+  it('allows state-changing cookie requests when the CSRF cookie and header match', async () => {
+    await request(app.getHttpServer())
+      .post('/')
+      .set('Origin', 'http://localhost:3000')
+      .set('Cookie', ['access_token=session-cookie; csrf_token=trusted-token'])
+      .set('X-CSRF-Token', 'trusted-token')
+      .send({ state: 'change' })
+      .expect(404);
   });
 });


### PR DESCRIPTION
## Summary

Closes #525.

Adds double-submit CSRF protection for cookie-authenticated, state-changing backend requests when credentialed CORS is enabled.

## Changes

- Added a backend security bootstrap that enables credentialed CORS and allows CSRF headers.
- Added CSRF double-submit middleware that mints a `csrf_token` cookie on safe requests and requires a matching `X-CSRF-Token` or `X-XSRF-Token` header for state-changing requests with cookies.
- Wired the security bootstrap into `main.ts`.
- Added e2e coverage for cross-origin state-changing cookie requests with and without a matching CSRF token.

## Testing/Verification

- `npm ci`
- `npm run build`
- `npx jest --config ./test/jest-e2e.json test/app.e2e-spec.ts --runInBand`
- `npx eslint src/main.ts src/security/app-security.ts src/security/csrf.middleware.ts test/app.e2e-spec.ts --max-warnings=0`

## Notes

I also tried `npm run test:e2e -- --runInBand`; it currently fails in an unrelated suite because `test/events-cqrs.e2e-spec.ts` imports missing `../src/events/events.module`. The touched app e2e suite passes.
