### PR TITLE
fix(contract): guard reward arithmetic overflow

### DIFF
--- a/contract/contracts/src/storage.rs
+++ b/contract/contracts/src/storage.rs
@@ -1,10 +1,18 @@
-use crate::types::{Config, DataKey, Tier, UserInfo, ChainConfig, CrossChainMessage};
+use crate::types::{ChainConfig, Config, CrossChainMessage, DataKey, Tier, UserInfo};
 
-
-use soroban_sdk::{Address, Env, Vec, Symbol, token};
+use soroban_sdk::{token, Address, Env, Vec};
 
 const TTL_INSTANCE: u32 = 17280 * 30; // 30 days
 const TTL_PERSISTENT: u32 = 17280 * 90; // 90 days
+const PRECISION: i128 = 1_000_000_000;
+
+/// Upper bound for per-second reward emission before precision scaling.
+///
+/// `update_reward` multiplies `reward_rate * PRECISION`; capping the stored
+/// emission rate here keeps that scaling inside i128 before any division by
+/// total supply.
+const MAX_REWARD_RATE: i128 = i128::MAX / PRECISION;
+const REWARD_ARITHMETIC_OVERFLOW: &str = "reward calculation overflow";
 
 // Batch storage operations for better gas efficiency
 pub struct StorageCache {
@@ -226,23 +234,68 @@ pub fn write_message_nonce(env: &Env, nonce: u64) {
     env.storage().instance().set(&DataKey::MessageNonce, &nonce);
 }
 
+fn bounded_reward_rate(reward_rate: i128) -> i128 {
+    if reward_rate <= 0 {
+        0
+    } else if reward_rate > MAX_REWARD_RATE {
+        MAX_REWARD_RATE
+    } else {
+        reward_rate
+    }
+}
+
+fn checked_reward_per_token(reward_rate: i128, total_supply: i128) -> Option<i128> {
+    if total_supply <= 0 {
+        return None;
+    }
+
+    bounded_reward_rate(reward_rate)
+        .checked_mul(PRECISION)
+        .and_then(|scaled_rate| scaled_rate.checked_div(total_supply))
+}
+
+fn checked_reward_per_token_stored(current: i128, increment: i128) -> Option<i128> {
+    current.checked_add(increment)
+}
+
+fn checked_user_reward_delta(
+    shares: i128,
+    reward_per_token_stored: i128,
+    reward_per_token_paid: i128,
+) -> Option<i128> {
+    shares
+        .checked_mul(reward_per_token_stored)
+        .and_then(|scaled_rewards| scaled_rewards.checked_div(PRECISION))
+        .and_then(|gross_rewards| gross_rewards.checked_sub(reward_per_token_paid))
+}
+
+fn checked_accumulated_rewards(current: i128, delta: i128) -> Option<i128> {
+    current.checked_add(delta)
+}
+
 pub fn update_reward(env: &Env, user: Option<&Address>) {
     let config = read_config(env);
-    let reward_token = token::Client::new(env, &config.reward_token);
     let staking_token = token::Client::new(env, &config.staking_token);
     let total_supply = staking_token.total_supply();
 
     if total_supply > 0 {
-        let reward_per_token = (config.reward_rate * PRECISION) / total_supply;
-        let mut reward_per_token_stored = read_reward_per_token_stored(env);
-        reward_per_token_stored += reward_per_token;
+        let reward_per_token = checked_reward_per_token(config.reward_rate, total_supply)
+            .unwrap_or_else(|| panic!("{}", REWARD_ARITHMETIC_OVERFLOW));
+        let reward_per_token_stored =
+            checked_reward_per_token_stored(read_reward_per_token_stored(env), reward_per_token)
+                .unwrap_or_else(|| panic!("{}", REWARD_ARITHMETIC_OVERFLOW));
         write_reward_per_token_stored(env, reward_per_token_stored);
 
         if let Some(user_addr) = user {
             if let Some(mut user_info) = read_user_info(env, user_addr) {
-                let rewards = (user_info.shares * reward_per_token_stored) / PRECISION
-                    - user_info.reward_per_token_paid;
-                user_info.rewards += rewards;
+                let rewards = checked_user_reward_delta(
+                    user_info.shares,
+                    reward_per_token_stored,
+                    user_info.reward_per_token_paid,
+                )
+                .unwrap_or_else(|| panic!("{}", REWARD_ARITHMETIC_OVERFLOW));
+                user_info.rewards = checked_accumulated_rewards(user_info.rewards, rewards)
+                    .unwrap_or_else(|| panic!("{}", REWARD_ARITHMETIC_OVERFLOW));
                 user_info.reward_per_token_paid = reward_per_token_stored;
                 write_user_info(env, user_addr, &user_info);
             }
@@ -250,4 +303,74 @@ pub fn update_reward(env: &Env, user: Option<&Address>) {
     }
 
     write_last_update_time(env, env.ledger().timestamp());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn caps_reward_rate_before_precision_scaling() {
+        let capped_scaled_rate = MAX_REWARD_RATE.checked_mul(PRECISION).unwrap();
+
+        assert_eq!(bounded_reward_rate(-1), 0);
+        assert_eq!(bounded_reward_rate(MAX_REWARD_RATE + 1), MAX_REWARD_RATE);
+        assert_eq!(
+            checked_reward_per_token(MAX_REWARD_RATE + 1, 1),
+            Some(capped_scaled_rate)
+        );
+    }
+
+    #[test]
+    fn detects_stored_reward_overflow() {
+        assert_eq!(checked_reward_per_token_stored(i128::MAX, 1), None);
+    }
+
+    #[test]
+    fn near_max_reward_rates_do_not_wrap_before_division() {
+        let total_supplies = [1, 7, 1_000_000, 1_000_000_000_000];
+
+        for offset in [0, 1, 1_000, 1_000_000] {
+            for total_supply in total_supplies {
+                let reward_rate = MAX_REWARD_RATE.saturating_sub(offset);
+                let expected = reward_rate
+                    .checked_mul(PRECISION)
+                    .and_then(|scaled_rate| scaled_rate.checked_div(total_supply));
+
+                assert_eq!(
+                    checked_reward_per_token(reward_rate, total_supply),
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn near_max_user_shares_do_not_wrap_reward_delta() {
+        let share_divisors = [1, 2, 1_000, 1_000_000];
+        let reward_divisors = [1, 2, 1_000, 1_000_000];
+        let paid_values = [0, 1, 1_000_000_000];
+
+        for share_divisor in share_divisors {
+            for reward_divisor in reward_divisors {
+                for reward_per_token_paid in paid_values {
+                    let shares = i128::MAX / share_divisor;
+                    let reward_per_token_stored = i128::MAX / reward_divisor;
+                    let expected = shares
+                        .checked_mul(reward_per_token_stored)
+                        .and_then(|scaled_rewards| scaled_rewards.checked_div(PRECISION))
+                        .and_then(|gross_rewards| gross_rewards.checked_sub(reward_per_token_paid));
+
+                    assert_eq!(
+                        checked_user_reward_delta(
+                            shares,
+                            reward_per_token_stored,
+                            reward_per_token_paid,
+                        ),
+                        expected
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Closes #511.

## Summary
- caps reward_rate before PRECISION scaling so i128 multiplication cannot wrap
- replaces reward_per_token accumulation and user reward math with checked_add/checked_mul/checked_sub helpers
- fails closed with a clear reward arithmetic panic instead of silently wrapping intermediate values
- adds deterministic near-max arithmetic tests around reward_rate, stored rewards, and user share calculations

## Validation
- rustup run stable-x86_64-pc-windows-gnu rustfmt --edition 2021 --check contract\contracts\src\storage.rs
- git diff --check

## Notes
- cargo +stable-x86_64-pc-windows-gnu check -p gathera-contracts is currently blocked by existing workspace baseline errors in sibling crates (missing generated contract clients / TryFromVal implementations in multisig_wallet_contract, ticket_contract, and escrow_contract).
- Local Windows target-test attempts were also blocked by missing linker tools (dlltool.exe for GNU, link.exe for MSVC, x86_64-w64-mingw32-clang for gnullvm), so this PR keeps the change scoped to storage.rs and documents the focused checks that could run here.