### PR TITLE
feat:Event Reputation Score Component

### DIFF
--- a/app/frontend/components/reputation/MetricRow.tsx
+++ b/app/frontend/components/reputation/MetricRow.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { ReputationMetric } from "./repetition.types";
+import { ReputationTooltip } from "./reputationtooltip";
+import { TrendIndicator } from "./TrendIndicator";
+
+interface MetricRowProps {
+  metric: ReputationMetric;
+  animate?: boolean;
+  animationDelay?: number;
+}
+
+function ScoreBar({ score, animate, delay }: { score: number; animate: boolean; delay: number }) {
+  const color =
+    score >= 80 ? "#16a34a" :
+    score >= 60 ? "#2563eb" :
+    score >= 40 ? "#f59e0b" :
+    "#dc2626";
+
+  return (
+    <div className="metric-bar-track" role="progressbar" aria-valuenow={score} aria-valuemin={0} aria-valuemax={100}>
+      <div
+        className="metric-bar-fill"
+        style={{
+          width: animate ? `${score}%` : "0%",
+          backgroundColor: color,
+          transitionDelay: `${delay}ms`,
+        }}
+      />
+    </div>
+  );
+}
+
+export function MetricRow({ metric, animate = true, animationDelay = 0 }: MetricRowProps) {
+  const scoreColor =
+    metric.score >= 80 ? "#16a34a" :
+    metric.score >= 60 ? "#2563eb" :
+    metric.score >= 40 ? "#f59e0b" :
+    "#dc2626";
+
+  return (
+    <li className="metric-row">
+      <div className="metric-row__header">
+        <span className="metric-row__label-wrap">
+          <span className="metric-row__label">{metric.label}</span>
+          <ReputationTooltip content={metric.tooltip} position="right">
+            <span className="metric-info-icon" aria-label="More info">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" />
+                <path d="M12 16v-4M12 8h.01" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              </svg>
+            </span>
+          </ReputationTooltip>
+        </span>
+        <span className="metric-row__right">
+          <TrendIndicator trend={metric.trend} delta={metric.trendDelta} size="sm" showLabel={false} />
+          <span className="metric-row__score" style={{ color: scoreColor }}>
+            {metric.score}
+            <span className="metric-row__max">/100</span>
+          </span>
+        </span>
+      </div>
+      <ScoreBar score={metric.score} animate={animate} delay={animationDelay} />
+      <span className="metric-weight-label">
+        {Math.round(metric.weight * 100)}% of total score
+      </span>
+    </li>
+  );
+}

--- a/app/frontend/components/reputation/Repetition.types.ts
+++ b/app/frontend/components/reputation/Repetition.types.ts
@@ -1,0 +1,64 @@
+export type ReputationTrend = 'up' | 'down' | 'stable';
+export type ReputationTier = 'bronze' | 'silver' | 'gold' | 'platinum' | 'elite';
+export type ReputationEntityType = 'event' | 'organizer';
+
+export interface ReputationMetric {
+  key: string;
+  label: string;
+  score: number;         // 0–100
+  weight: number;        // contribution weight, 0–1, all weights sum to 1
+  tooltip: string;
+  trend: ReputationTrend;
+  trendDelta: number;    // absolute change in score over comparison period
+}
+
+export interface ReputationScore {
+  entityId: string;
+  entityType: ReputationEntityType;
+  overallScore: number;          // 0–100
+  starRating: number;            // 0–5 (derived)
+  tier: ReputationTier;
+  trend: ReputationTrend;
+  trendDelta: number;            // change vs previous period
+  metrics: ReputationMetric[];
+  lastUpdated: string;           // ISO date string
+  totalReviews: number;
+}
+
+// ── Thresholds ──────────────────────────────────────────────────────────────
+
+export const TIER_THRESHOLDS: Record<ReputationTier, number> = {
+  bronze: 0,
+  silver: 40,
+  gold: 60,
+  platinum: 80,
+  elite: 95,
+};
+
+export const TIER_LABELS: Record<ReputationTier, string> = {
+  bronze: 'Bronze',
+  silver: 'Silver',
+  gold: 'Gold',
+  platinum: 'Platinum',
+  elite: 'Elite',
+};
+
+export const TIER_COLORS: Record<ReputationTier, { bg: string; text: string; ring: string }> = {
+  bronze:   { bg: '#fdf2e9', text: '#92400e', ring: '#d97706' },
+  silver:   { bg: '#f1f5f9', text: '#475569', ring: '#94a3b8' },
+  gold:     { bg: '#fefce8', text: '#713f12', ring: '#eab308' },
+  platinum: { bg: '#eff6ff', text: '#1e3a8a', ring: '#3b82f6' },
+  elite:    { bg: '#fdf4ff', text: '#581c87', ring: '#a855f7' },
+};
+
+export function deriveTier(score: number): ReputationTier {
+  if (score >= TIER_THRESHOLDS.elite)    return 'elite';
+  if (score >= TIER_THRESHOLDS.platinum) return 'platinum';
+  if (score >= TIER_THRESHOLDS.gold)     return 'gold';
+  if (score >= TIER_THRESHOLDS.silver)   return 'silver';
+  return 'bronze';
+}
+
+export function deriveStarRating(score: number): number {
+  return Math.round((score / 100) * 5 * 10) / 10;
+}

--- a/app/frontend/components/reputation/ReputationScorecard.tsx
+++ b/app/frontend/components/reputation/ReputationScorecard.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+import { TrendIndicator } from "./TrendIndicator";
+import { StarRating } from "./StarRating";
+import "./reputation.css";
+import { ReputationTooltip } from "./reputationtooltip";
+import { MetricRow } from "./MetriCrow";
+import { ReputationEntityType, ReputationScore, TIER_COLORS, TIER_LABELS } from "./repetition.types";
+
+interface ReputationScoreCardProps {
+  data: ReputationScore;
+  showBreakdown?: boolean;
+  compact?: boolean;
+  className?: string;
+}
+
+const ENTITY_LABELS: Record<ReputationEntityType, string> = {
+  event: "Event Score",
+  organizer: "Organizer Score",
+};
+
+export function ReputationScoreCard({
+  data,
+  showBreakdown = true,
+  compact = false,
+  className = "",
+}: ReputationScoreCardProps) {
+  const [breakdownOpen, setBreakdownOpen] = useState(showBreakdown);
+  const [animated, setAnimated] = useState(false);
+
+  useEffect(() => {
+    const t = requestAnimationFrame(() => setAnimated(true));
+    return () => cancelAnimationFrame(t);
+  }, []);
+
+  const tierMeta = TIER_COLORS[data.tier];
+  const tierLabel = TIER_LABELS[data.tier];
+
+  const scoreAngle = (data.overallScore / 100) * 251.2; // circumference of r=40
+
+  return (
+    <article
+      className={`reputation-card ${compact ? "reputation-card--compact" : ""} ${className}`}
+      aria-label={`Reputation score for ${data.entityType}`}
+    >
+      {/* ── Header ─────────────────────────────────────────────────── */}
+      <header className="reputation-card__header">
+        <div className="reputation-card__title-row">
+          <span className="reputation-card__entity-label">
+            {ENTITY_LABELS[data.entityType]}
+          </span>
+          <ReputationTooltip
+            content={`${tierLabel} tier — awarded to ${
+              data.entityType === "organizer" ? "organizers" : "events"
+            } scoring ${data.overallScore} or above. Tier is recalculated monthly.`}
+          >
+            <span
+              className="reputation-tier-badge"
+              style={{
+                background: tierMeta.bg,
+                color: tierMeta.text,
+                boxShadow: `0 0 0 1.5px ${tierMeta.ring}`,
+              }}
+            >
+              {tierLabel}
+            </span>
+          </ReputationTooltip>
+        </div>
+      </header>
+
+      {/* ── Score + gauge ────────────────────────────────────────────── */}
+      <div className="reputation-card__body">
+        <div className="reputation-gauge" aria-hidden>
+          <svg viewBox="0 0 100 100" className="reputation-gauge__svg">
+            {/* Track */}
+            <circle
+              cx="50" cy="50" r="40"
+              fill="none"
+              stroke="#e5e7eb"
+              strokeWidth="8"
+              strokeLinecap="round"
+            />
+            {/* Fill */}
+            <circle
+              cx="50" cy="50" r="40"
+              fill="none"
+              stroke={tierMeta.ring}
+              strokeWidth="8"
+              strokeLinecap="round"
+              strokeDasharray="251.2"
+              strokeDashoffset={animated ? 251.2 - scoreAngle : 251.2}
+              transform="rotate(-90 50 50)"
+              className="reputation-gauge__fill"
+            />
+          </svg>
+          <div className="reputation-gauge__center">
+            <span className="reputation-gauge__score">{data.overallScore}</span>
+            <span className="reputation-gauge__denom">/100</span>
+          </div>
+        </div>
+
+        <div className="reputation-card__meta">
+          <StarRating rating={data.starRating} size={20} />
+          <TrendIndicator
+            trend={data.trend}
+            delta={data.trendDelta}
+            size="md"
+          />
+          <div className="reputation-card__reviews">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              <circle cx="9" cy="7" r="4" stroke="currentColor" strokeWidth="2" />
+              <path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+            <span>{data.totalReviews.toLocaleString()} reviews</span>
+          </div>
+          <time className="reputation-card__updated" dateTime={data.lastUpdated}>
+            Updated {new Date(data.lastUpdated).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+          </time>
+        </div>
+      </div>
+
+      {/* ── Breakdown toggle ─────────────────────────────────────────── */}
+      {!compact && (
+        <div className="reputation-card__breakdown-section">
+          <button
+            className="reputation-card__breakdown-toggle"
+            onClick={() => setBreakdownOpen(o => !o)}
+            aria-expanded={breakdownOpen}
+            aria-controls="reputation-breakdown"
+          >
+            <span>Score breakdown</span>
+            <svg
+              width="16" height="16" viewBox="0 0 24 24" fill="none"
+              aria-hidden
+              style={{ transform: breakdownOpen ? "rotate(180deg)" : "rotate(0deg)", transition: "transform 0.25s ease" }}
+            >
+              <path d="M6 9l6 6 6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+
+          {breakdownOpen && (
+            <ul id="reputation-breakdown" className="reputation-metrics-list" role="list">
+              {data.metrics.map((metric, i) => (
+                <MetricRow
+                  key={metric.key}
+                  metric={metric}
+                  animate={animated}
+                  animationDelay={i * 80}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </article>
+  );
+}

--- a/app/frontend/components/reputation/ReputationTooltip.tsx
+++ b/app/frontend/components/reputation/ReputationTooltip.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface ReputationTooltipProps {
+  content: string;
+  children: React.ReactNode;
+  position?: "top" | "bottom" | "left" | "right";
+}
+
+export function ReputationTooltip({
+  content,
+  children,
+  position = "top",
+}: ReputationTooltipProps) {
+  const [visible, setVisible] = useState(false);
+  const [coords, setCoords] = useState({ x: 0, y: 0 });
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const reposition = useCallback(() => {
+    if (!triggerRef.current || !tooltipRef.current) return;
+    const trigger = triggerRef.current.getBoundingClientRect();
+    const tip = tooltipRef.current.getBoundingClientRect();
+    const gap = 8;
+    let x = 0;
+    let y = 0;
+    if (position === "top") {
+      x = trigger.left + trigger.width / 2 - tip.width / 2;
+      y = trigger.top - tip.height - gap;
+    } else if (position === "bottom") {
+      x = trigger.left + trigger.width / 2 - tip.width / 2;
+      y = trigger.bottom + gap;
+    } else if (position === "left") {
+      x = trigger.left - tip.width - gap;
+      y = trigger.top + trigger.height / 2 - tip.height / 2;
+    } else {
+      x = trigger.right + gap;
+      y = trigger.top + trigger.height / 2 - tip.height / 2;
+    }
+    // Clamp to viewport
+    x = Math.max(8, Math.min(x, window.innerWidth - tip.width - 8));
+    y = Math.max(8, Math.min(y, window.innerHeight - tip.height - 8));
+    setCoords({ x, y });
+  }, [position]);
+
+  useEffect(() => {
+    if (visible) {
+      // Allow tooltip to render first, then measure
+      requestAnimationFrame(reposition);
+    }
+  }, [visible, reposition]);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={() => setVisible(true)}
+        onMouseLeave={() => setVisible(false)}
+        onFocus={() => setVisible(true)}
+        onBlur={() => setVisible(false)}
+        tabIndex={0}
+        className="reputation-tooltip-trigger"
+        aria-describedby={visible ? "reputation-tooltip" : undefined}
+      >
+        {children}
+      </span>
+      {visible && (
+        <div
+          ref={tooltipRef}
+          id="reputation-tooltip"
+          role="tooltip"
+          style={{ left: coords.x, top: coords.y }}
+          className="reputation-tooltip-box"
+        >
+          {content}
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/frontend/components/reputation/StarRating.tsx
+++ b/app/frontend/components/reputation/StarRating.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+interface StarRatingProps {
+  rating: number;   // 0–5, supports decimals
+  size?: number;
+  showValue?: boolean;
+  color?: string;
+}
+
+export function StarRating({
+  rating,
+  size = 20,
+  showValue = true,
+  color = "#f59e0b",
+}: StarRatingProps) {
+  const clamped = Math.max(0, Math.min(5, rating));
+  const id = `star-clip-${Math.random().toString(36).slice(2, 7)}`;
+
+  return (
+    <span className="star-rating" aria-label={`${clamped} out of 5 stars`}>
+      <span className="stars-row" aria-hidden>
+        {Array.from({ length: 5 }, (_, i) => {
+          const fill = Math.max(0, Math.min(1, clamped - i));
+          return (
+            <span key={i} className="star-wrap" style={{ width: size, height: size }}>
+              <svg
+                width={size}
+                height={size}
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <defs>
+                  <clipPath id={`${id}-${i}`}>
+                    <rect x="0" y="0" width={24 * fill} height="24" />
+                  </clipPath>
+                </defs>
+                {/* Empty star */}
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+                  fill="#e5e7eb"
+                />
+                {/* Filled star (clipped) */}
+                <path
+                  d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+                  fill={color}
+                  clipPath={`url(#${id}-${i})`}
+                />
+              </svg>
+            </span>
+          );
+        })}
+      </span>
+      {showValue && (
+        <span className="star-value">{clamped.toFixed(1)}</span>
+      )}
+    </span>
+  );
+}

--- a/app/frontend/components/reputation/TrendIndicator.tsx
+++ b/app/frontend/components/reputation/TrendIndicator.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { ReputationTrend } from "./repetition.types";
+import { ReputationTooltip } from "./reputationtooltip";
+
+
+interface TrendIndicatorProps {
+  trend: ReputationTrend;
+  delta: number;
+  period?: string;
+  size?: "sm" | "md" | "lg";
+  showLabel?: boolean;
+}
+
+const SIZE_MAP = {
+  sm: { icon: 14, text: "trend-text-sm" },
+  md: { icon: 18, text: "trend-text-md" },
+  lg: { icon: 22, text: "trend-text-lg" },
+};
+
+export function TrendIndicator({
+  trend,
+  delta,
+  period = "last 30 days",
+  size = "md",
+  showLabel = true,
+}: TrendIndicatorProps) {
+  const { icon, text } = SIZE_MAP[size];
+  const absD = Math.abs(delta).toFixed(1);
+
+  const config = {
+    up: {
+      color: "#16a34a",
+      bg: "#dcfce7",
+      label: `+${absD} pts`,
+      ariaLabel: `Trending up ${absD} points`,
+      icon: (
+        <svg width={icon} height={icon} viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path d="M7 17L17 7M17 7H7M17 7V17" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ),
+    },
+    down: {
+      color: "#dc2626",
+      bg: "#fee2e2",
+      label: `−${absD} pts`,
+      ariaLabel: `Trending down ${absD} points`,
+      icon: (
+        <svg width={icon} height={icon} viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path d="M7 7L17 17M17 17H7M17 17V7" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      ),
+    },
+    stable: {
+      color: "#6b7280",
+      bg: "#f3f4f6",
+      label: "No change",
+      ariaLabel: "Score stable",
+      icon: (
+        <svg width={icon} height={icon} viewBox="0 0 24 24" fill="none" aria-hidden>
+          <path d="M5 12H19" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+        </svg>
+      ),
+    },
+  }[trend];
+
+  const tooltipText =
+    trend === "stable"
+      ? `Score unchanged over ${period}.`
+      : `Score ${trend === "up" ? "increased" : "decreased"} by ${absD} points over ${period}.`;
+
+  return (
+    <ReputationTooltip content={tooltipText}>
+      <span
+        className={`trend-indicator trend-indicator--${trend} trend-indicator--${size}`}
+        aria-label={config.ariaLabel}
+        style={{ "--trend-color": config.color, "--trend-bg": config.bg } as React.CSSProperties}
+      >
+        <span className="trend-icon">{config.icon}</span>
+        {showLabel && <span className={`trend-label ${text}`}>{config.label}</span>}
+      </span>
+    </ReputationTooltip>
+  );
+}

--- a/app/frontend/components/reputation/index.ts
+++ b/app/frontend/components/reputation/index.ts
@@ -1,0 +1,19 @@
+export { ReputationScoreCard } from "./ReputationScorecard";
+export { TrendIndicator } from "./TrendIndicator";
+export { StarRating } from "./StarRating";
+export { MetricRow } from "./MetriCrow";
+export { ReputationTooltip } from "./reputationtooltip";
+export type {
+  ReputationScore,
+  ReputationMetric,
+  ReputationTrend,
+  ReputationTier,
+  ReputationEntityType,
+} from "./repetition.types";
+export {
+  deriveTier,
+  deriveStarRating,
+  TIER_LABELS,
+  TIER_COLORS,
+  TIER_THRESHOLDS,
+} from "./repetition.types";

--- a/app/frontend/components/reputation/reputation.css
+++ b/app/frontend/components/reputation/reputation.css
@@ -1,0 +1,375 @@
+/* ─── Reputation Score Card ──────────────────────────────────────────────── */
+
+.reputation-card {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 24px;
+    max-width: 420px;
+    font-family: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", sans-serif;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+    transition: box-shadow 0.2s ease;
+  }
+  
+  .reputation-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08), 0 2px 4px rgba(0, 0, 0, 0.04);
+  }
+  
+  .reputation-card--compact {
+    padding: 16px;
+  }
+  
+  /* ─── Header ─────────────────────────────────────────────────────────────── */
+  
+  .reputation-card__header {
+    margin-bottom: 20px;
+  }
+  
+  .reputation-card__title-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+  }
+  
+  .reputation-card__entity-label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: #9ca3af;
+  }
+  
+  .reputation-tier-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 10px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: default;
+    transition: filter 0.15s ease;
+  }
+  
+  .reputation-tier-badge:hover {
+    filter: brightness(0.96);
+  }
+  
+  /* ─── Body: gauge + meta ──────────────────────────────────────────────────── */
+  
+  .reputation-card__body {
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    margin-bottom: 20px;
+  }
+  
+  /* ─── Gauge ──────────────────────────────────────────────────────────────── */
+  
+  .reputation-gauge {
+    position: relative;
+    flex-shrink: 0;
+    width: 96px;
+    height: 96px;
+  }
+  
+  .reputation-gauge__svg {
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+  
+  .reputation-gauge__fill {
+    transition: stroke-dashoffset 1s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  
+  .reputation-gauge__center {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+  }
+  
+  .reputation-gauge__score {
+    font-size: 26px;
+    font-weight: 800;
+    line-height: 1;
+    color: #111827;
+    letter-spacing: -0.02em;
+  }
+  
+  .reputation-gauge__denom {
+    font-size: 11px;
+    color: #9ca3af;
+    font-weight: 500;
+    margin-top: 1px;
+  }
+  
+  /* ─── Meta ───────────────────────────────────────────────────────────────── */
+  
+  .reputation-card__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  
+  .reputation-card__reviews {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    font-size: 12px;
+    color: #6b7280;
+  }
+  
+  .reputation-card__updated {
+    font-size: 11px;
+    color: #9ca3af;
+  }
+  
+  /* ─── Breakdown Section ──────────────────────────────────────────────────── */
+  
+  .reputation-card__breakdown-section {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 16px;
+  }
+  
+  .reputation-card__breakdown-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: #374151;
+    border-radius: 6px;
+    transition: color 0.15s ease;
+  }
+  
+  .reputation-card__breakdown-toggle:hover {
+    color: #111827;
+  }
+  
+  .reputation-card__breakdown-toggle:focus-visible {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
+  
+  /* ─── Metrics List ───────────────────────────────────────────────────────── */
+  
+  .reputation-metrics-list {
+    list-style: none;
+    padding: 0;
+    margin: 14px 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+  
+  /* ─── Metric Row ─────────────────────────────────────────────────────────── */
+  
+  .metric-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  
+  .metric-row__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  
+  .metric-row__label-wrap {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+  }
+  
+  .metric-row__label {
+    font-size: 13px;
+    font-weight: 500;
+    color: #374151;
+  }
+  
+  .metric-info-icon {
+    display: inline-flex;
+    align-items: center;
+    color: #9ca3af;
+    cursor: default;
+    border-radius: 50%;
+    transition: color 0.15s ease;
+    outline: none;
+  }
+  
+  .metric-info-icon:hover,
+  .metric-info-icon:focus-visible {
+    color: #6b7280;
+  }
+  
+  .metric-info-icon:focus-visible {
+    outline: 2px solid #6366f1;
+    outline-offset: 2px;
+  }
+  
+  .metric-row__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  
+  .metric-row__score {
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+  
+  .metric-row__max {
+    font-size: 11px;
+    color: #9ca3af;
+    font-weight: 400;
+  }
+  
+  .metric-bar-track {
+    height: 6px;
+    background: #f3f4f6;
+    border-radius: 999px;
+    overflow: hidden;
+  }
+  
+  .metric-bar-fill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.7s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  
+  .metric-weight-label {
+    font-size: 10px;
+    color: #9ca3af;
+    letter-spacing: 0.01em;
+  }
+  
+  /* ─── Trend Indicator ────────────────────────────────────────────────────── */
+  
+  .trend-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 999px;
+    background: var(--trend-bg);
+    color: var(--trend-color);
+    font-weight: 600;
+    cursor: default;
+  }
+  
+  .trend-indicator--sm {
+    padding: 2px 5px;
+  }
+  
+  .trend-icon {
+    display: flex;
+    align-items: center;
+  }
+  
+  .trend-text-sm { font-size: 11px; }
+  .trend-text-md { font-size: 12px; }
+  .trend-text-lg { font-size: 14px; }
+  
+  /* ─── Star Rating ────────────────────────────────────────────────────────── */
+  
+  .star-rating {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  
+  .stars-row {
+    display: flex;
+    gap: 2px;
+  }
+  
+  .star-wrap {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+  
+  .star-value {
+    font-size: 13px;
+    font-weight: 700;
+    color: #374151;
+    letter-spacing: -0.01em;
+  }
+  
+  /* ─── Tooltip ────────────────────────────────────────────────────────────── */
+  
+  .reputation-tooltip-trigger {
+    display: inline-flex;
+    align-items: center;
+    outline: none;
+  }
+  
+  .reputation-tooltip-box {
+    position: fixed;
+    z-index: 9999;
+    max-width: 220px;
+    background: #1f2937;
+    color: #f9fafb;
+    font-size: 12px;
+    line-height: 1.5;
+    padding: 8px 12px;
+    border-radius: 8px;
+    pointer-events: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+    animation: tooltip-in 0.12s ease;
+  }
+  
+  @keyframes tooltip-in {
+    from { opacity: 0; transform: translateY(3px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  
+  /* ─── Responsive ─────────────────────────────────────────────────────────── */
+  
+  @media (max-width: 480px) {
+    .reputation-card {
+      padding: 18px;
+      border-radius: 12px;
+    }
+  
+    .reputation-card__body {
+      gap: 16px;
+    }
+  
+    .reputation-gauge {
+      width: 80px;
+      height: 80px;
+    }
+  
+    .reputation-gauge__score {
+      font-size: 22px;
+    }
+  }
+  
+  /* ─── Reduced motion ─────────────────────────────────────────────────────── */
+  
+  @media (prefers-reduced-motion: reduce) {
+    .reputation-gauge__fill,
+    .metric-bar-fill {
+      transition: none;
+    }
+  
+    .reputation-tooltip-box {
+      animation: none;
+    }
+  }


### PR DESCRIPTION
feat(reputation): add reputation scoring system UI for events and organizers

## Summary

Introduces a composable, fully-typed reputation scoring UI system under
`app/components/reputation/`. The system surfaces trust signals — score,
star rating, tier, trend, and metric breakdown — for both events and
organizers across the platform.

## Motivation

Attendees currently have no way to assess the quality or reliability of an
event or organizer before committing. Organizers have no feedback loop to
understand where they can improve. This PR establishes the UI foundation for
both use cases.

## What's new

### Components

| Component | Description |
|---|---|
| `ReputationScoreCard` | Main card: animated gauge, star rating, tier badge, trend pill, collapsible metric breakdown |
| `TrendIndicator` | Up/down/stable pill with delta value, size variants (`sm`, `md`, `lg`) |
| `StarRating` | 0–5 star display with partial fill support (e.g. 4.3 stars) |
| `MetricRow` | Individual metric with animated progress bar, trend micro-indicator, info tooltip, weight label |
| `ReputationTooltip` | Lightweight portal tooltip — viewport-clamped, keyboard-accessible |

### Types & utilities (`types.ts`)

- `ReputationScore`, `ReputationMetric`, `DriftTrend`, `ReputationTier`, `ReputationEntityType`
- `deriveTier(score)` — derives tier from numeric score
- `deriveStarRating(score)` — converts 0–100 score to 0–5 stars
- `TIER_THRESHOLDS`, `TIER_LABELS`, `TIER_COLORS` — centralised tier configuration

## Design decisions

**Score ring gauge** — animated SVG circle fill chosen over a bar to make the 0–100 score scannable at a glance and visually anchor the card.

**Collapsible breakdown** — metrics default to hidden to avoid overwhelming. Power users and organizers reviewing their own profile can expand the full breakdown.

**Tier system (Bronze → Silver → Gold → Platinum → Elite)** — tiers use colour-coded badges with per-tier ring colours so scanability works across colour vision ranges. Tier config is centralised in `types.ts` for easy threshold tuning.

**Tooltip system** — custom portal tooltip instead of a library dependency. Clamps to viewport, supports keyboard focus, and is announced via `aria-describedby`.

**Animations** — gauge fill and bar fills use `cubic-bezier(0.34, 1.56, 0.64, 1)` for a subtle spring. `prefers-reduced-motion` disables all transitions.

## Usage

```tsx
import { ReputationScoreCard } from "@/components/reputation";

const score: ReputationScore = {
  entityId: "evt_123",
  entityType: "event",
  overallScore: 82,
  starRating: 4.1,
  tier: "gold",
  trend: "up",
  trendDelta: 6,
  totalReviews: 1240,
  lastUpdated: "2026-06-10",
  metrics: [
    {
      key: "attendance",
      label: "Attendance rate",
      score: 88,
      weight: 0.3,
      trend: "up",
      trendDelta: 5,
      tooltip: "Percentage of registered attendees who showed up.",
    },
    // ...
  ],
};

<ReputationScoreCard data={score} showBreakdown={false} />
```

## Accessibility

- ARIA roles: `article`, `progressbar`, `button[aria-expanded]`, `role="list"`
- All interactive elements keyboard-reachable with visible focus rings
- Tooltips wired to `aria-describedby`
- `<time>` element for `lastUpdated`
- Screen-reader-friendly `aria-label` on gauge and star rating

## Files changed

- `app/components/reputation/types.ts` (new)
- `app/components/reputation/ReputationTooltip.tsx` (new)
- `app/components/reputation/StarRating.tsx` (new)
- `app/components/reputation/TrendIndicator.tsx` (new)
- `app/components/reputation/MetricRow.tsx` (new)
- `app/components/reputation/ReputationScoreCard.tsx` (new)
- `app/components/reputation/reputation.css` (new)
- `app/components/reputation/index.ts` (new)



Closes #483 