### PR TITLE
fix: validate chain address formats

### DIFF
--- a/contract/common/src/lib.rs
+++ b/contract/common/src/lib.rs
@@ -1,7 +1,7 @@
 //! Gathera common utilities
 //! Minimal stub — full implementation pending Soroban SDK migration
 
-use soroban_sdk::{Address, Symbol, String, Env};
+use soroban_sdk::{Address, Bytes, Env, String, Symbol};
 
 /// Common status enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -40,10 +40,141 @@ pub type ContractResult<T> = Result<T, CommonError>;
 /// Validation utilities — stub
 pub struct ValidationUtils;
 impl ValidationUtils {
-    pub fn validate_address(_address: &Address) -> bool { true }
+    pub fn validate_address(address: &Address) -> bool {
+        Self::validate_generic_address(&address.to_string())
+    }
+
+    pub fn validate_evm_address(env: &Env, address: &String) -> bool {
+        let bytes = address.to_bytes();
+        if bytes.len() != 42 || bytes.get(0) != Some(b'0') || bytes.get(1) != Some(b'x') {
+            return false;
+        }
+
+        let mut lowercase = Bytes::new(env);
+        let mut non_zero = false;
+        for i in 2..42 {
+            let Some(byte) = bytes.get(i) else {
+                return false;
+            };
+            let Some(lower) = Self::to_lower_hex(byte) else {
+                return false;
+            };
+            if lower != b'0' {
+                non_zero = true;
+            }
+            lowercase.push_back(lower);
+        }
+
+        if !non_zero {
+            return false;
+        }
+
+        let hash = env.crypto().keccak256(&lowercase).to_array();
+        for i in 0..40 {
+            let byte = bytes.get(i + 2).unwrap();
+            if Self::is_hex_alpha(byte) {
+                let hash_byte = hash[(i / 2) as usize];
+                let nibble = if i % 2 == 0 {
+                    (hash_byte >> 4) & 0x0f
+                } else {
+                    hash_byte & 0x0f
+                };
+                let expected_uppercase = nibble >= 8;
+                if expected_uppercase != Self::is_upper_hex(byte) {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    pub fn validate_stellar_address(address: &String) -> bool {
+        let bytes = address.to_bytes();
+        if bytes.len() != 56 || bytes.get(0) != Some(b'G') {
+            return false;
+        }
+
+        if Self::is_zero_stellar_account(&bytes) {
+            return false;
+        }
+
+        for i in 0..56 {
+            let Some(byte) = bytes.get(i) else {
+                return false;
+            };
+            if !Self::is_stellar_base32(byte) {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    pub fn validate_generic_address(address: &String) -> bool {
+        let bytes = address.to_bytes();
+        if bytes.is_empty()
+            || Self::is_zero_evm_address(&bytes)
+            || Self::is_zero_stellar_account(&bytes)
+        {
+            return false;
+        }
+
+        for byte in bytes.iter() {
+            if byte > 0x7f {
+                return false;
+            }
+        }
+
+        true
+    }
+
     pub fn validate_symbol(symbol: &Symbol) -> bool {
         let s = symbol.to_string();
         !s.is_empty() && s.len() <= 32
+    }
+
+    fn to_lower_hex(byte: u8) -> Option<u8> {
+        match byte {
+            b'0'..=b'9' => Some(byte),
+            b'a'..=b'f' => Some(byte),
+            b'A'..=b'F' => Some(byte + 32),
+            _ => None,
+        }
+    }
+
+    fn is_hex_alpha(byte: u8) -> bool {
+        matches!(byte, b'a'..=b'f' | b'A'..=b'F')
+    }
+
+    fn is_upper_hex(byte: u8) -> bool {
+        matches!(byte, b'A'..=b'F')
+    }
+
+    fn is_stellar_base32(byte: u8) -> bool {
+        matches!(byte, b'A'..=b'Z' | b'2'..=b'7')
+    }
+
+    fn is_zero_evm_address(bytes: &Bytes) -> bool {
+        if bytes.len() != 42 || bytes.get(0) != Some(b'0') || bytes.get(1) != Some(b'x') {
+            return false;
+        }
+
+        for i in 2..42 {
+            if bytes.get(i) != Some(b'0') {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn is_zero_stellar_account(bytes: &Bytes) -> bool {
+        let zero = Bytes::from_array(
+            bytes.env(),
+            b"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        );
+        bytes == &zero
     }
 }
 
@@ -89,5 +220,78 @@ pub mod errors {
         pub const INVALID_INPUT: u32 = 1000;
         pub const UNAUTHORIZED: u32 = 1001;
         pub const NOT_FOUND: u32 = 1002;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ValidationUtils;
+    use soroban_sdk::{Env, String};
+
+    fn sdk_string(env: &Env, value: &str) -> String {
+        String::from_str(env, value)
+    }
+
+    #[test]
+    fn evm_validation_accepts_eip55_checksum() {
+        let env = Env::default();
+        let address = sdk_string(&env, "0x52908400098527886E0F7030069857D2E4169EE7");
+
+        assert!(ValidationUtils::validate_evm_address(&env, &address));
+    }
+
+    #[test]
+    fn evm_validation_rejects_zero_oversized_unicode_and_bad_checksum() {
+        let env = Env::default();
+        let zero = sdk_string(&env, "0x0000000000000000000000000000000000000000");
+        let oversized = sdk_string(&env, "0x52908400098527886E0F7030069857D2E4169EE70");
+        let unicode = sdk_string(&env, "0x52908400098527886E0F7030069857D2E4169EE\u{96ea}");
+        let bad_checksum = sdk_string(&env, "0x52908400098527886e0F7030069857D2E4169EE7");
+
+        assert!(!ValidationUtils::validate_evm_address(&env, &zero));
+        assert!(!ValidationUtils::validate_evm_address(&env, &oversized));
+        assert!(!ValidationUtils::validate_evm_address(&env, &unicode));
+        assert!(!ValidationUtils::validate_evm_address(&env, &bad_checksum));
+    }
+
+    #[test]
+    fn stellar_validation_enforces_prefix_length_and_ascii_base32() {
+        let env = Env::default();
+        let valid = sdk_string(
+            &env,
+            "GBZXN7PIRZGNMHGAFAH4K2BC5VJSENLOK5LTMSAJCNAP2FXYIC44AGIL",
+        );
+        let wrong_prefix = sdk_string(
+            &env,
+            "CBZXN7PIRZGNMHGAFAH4K2BC5VJSENLOK5LTMSAJCNAP2FXYIC44AGIL",
+        );
+        let short = sdk_string(
+            &env,
+            "GBZXN7PIRZGNMHGAFAH4K2BC5VJSENLOK5LTMSAJCNAP2FXYIC44AGI",
+        );
+        let unicode = sdk_string(
+            &env,
+            "GBZXN7PIRZGNMHGAFAH4K2BC5VJSENLOK5LTMSAJCNAP2FXYIC44\u{96ea}",
+        );
+
+        assert!(ValidationUtils::validate_stellar_address(&valid));
+        assert!(!ValidationUtils::validate_stellar_address(&wrong_prefix));
+        assert!(!ValidationUtils::validate_stellar_address(&short));
+        assert!(!ValidationUtils::validate_stellar_address(&unicode));
+    }
+
+    #[test]
+    fn generic_validation_rejects_known_zero_addresses() {
+        let env = Env::default();
+        let evm_zero = sdk_string(&env, "0x0000000000000000000000000000000000000000");
+        let stellar_zero = sdk_string(
+            &env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        );
+        let normal = sdk_string(&env, "external-address-1");
+
+        assert!(!ValidationUtils::validate_generic_address(&evm_zero));
+        assert!(!ValidationUtils::validate_generic_address(&stellar_zero));
+        assert!(ValidationUtils::validate_generic_address(&normal));
     }
 }

--- a/contract/contracts/src/chain_abstraction.rs
+++ b/contract/contracts/src/chain_abstraction.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{contract, contractimpl, Address, Env, Symbol, Vec, BytesN};
+use gathera_common::ValidationUtils;
+use soroban_sdk::{contract, contractimpl, Address, Env, String, Symbol, Vec};
 
 use crate::storage::{StorageCache, *};
 use crate::types::{Config, DataKey, Tier, UserInfo, ChainConfig, CrossChainMessage, ETHEREUM_CHAIN_ID, STELLAR_CHAIN_ID, POLYGON_CHAIN_ID, ARBITRUM_CHAIN_ID, OPTIMISM_CHAIN_ID, BASE_CHAIN_ID};
@@ -203,34 +204,43 @@ impl ChainAbstraction {
         }
     }
 
-    /// Validate address format for specific chain
+    /// Validate Soroban address format for a specific chain.
+    ///
+    /// EVM addresses are not representable as `soroban_sdk::Address`, so this
+    /// compatibility entrypoint converts the Soroban address to its StrKey form
+    /// and applies the same chain-specific string validator used by
+    /// `validate_chain_address_string`.
     pub fn validate_chain_address(env: Env, chain_id: u32, address: &Address) -> bool {
+        let address_string = address.to_string();
+        Self::validate_chain_address_string(env, chain_id, address_string)
+    }
+
+    /// Validate a raw chain address string for a specific chain.
+    pub fn validate_chain_address_string(env: Env, chain_id: u32, address: String) -> bool {
         match chain_id {
-            ETHEREUM_CHAIN_ID => Self::validate_ethereum_address(address),
-            POLYGON_CHAIN_ID => Self::validate_ethereum_address(address),
-            ARBITRUM_CHAIN_ID => Self::validate_ethereum_address(address),
-            OPTIMISM_CHAIN_ID => Self::validate_ethereum_address(address),
-            BASE_CHAIN_ID => Self::validate_ethereum_address(address),
-            STELLAR_CHAIN_ID => Self::validate_stellar_address(address),
-            _ => Self::validate_generic_address(address),
+            ETHEREUM_CHAIN_ID => Self::validate_ethereum_address(&env, &address),
+            POLYGON_CHAIN_ID => Self::validate_ethereum_address(&env, &address),
+            ARBITRUM_CHAIN_ID => Self::validate_ethereum_address(&env, &address),
+            OPTIMISM_CHAIN_ID => Self::validate_ethereum_address(&env, &address),
+            BASE_CHAIN_ID => Self::validate_ethereum_address(&env, &address),
+            STELLAR_CHAIN_ID => Self::validate_stellar_address(&address),
+            _ => Self::validate_generic_address(&address),
         }
     }
 
     /// Validate Ethereum-compatible address
-    fn validate_ethereum_address(address: &Address) -> bool {
-        // Basic validation - in production, would include checksum validation
-        true // Placeholder
+    fn validate_ethereum_address(env: &Env, address: &String) -> bool {
+        ValidationUtils::validate_evm_address(env, address)
     }
 
     /// Validate Stellar address
-    fn validate_stellar_address(address: &Address) -> bool {
-        // Stellar address validation (G... format, 56 characters)
-        true // Placeholder
+    fn validate_stellar_address(address: &String) -> bool {
+        ValidationUtils::validate_stellar_address(address)
     }
 
     /// Validate generic address
-    fn validate_generic_address(_address: &Address) -> bool {
-        true // Placeholder
+    fn validate_generic_address(address: &String) -> bool {
+        ValidationUtils::validate_generic_address(address)
     }
 
     /// Get chain-specific bridge address


### PR DESCRIPTION
Closes #509

## Summary
- replace always-true chain address validators with real validation rules
- enforce EIP-55 checksummed EVM addresses with Soroban keccak256 and reject the zero address
- enforce Stellar `G...`/56-character/base32 addresses and reject the zero account placeholder
- route polygon, arbitrum, optimism, and base through the shared EVM validator
- keep the existing `Address` entrypoint and add a raw string validator for external chain addresses

## Tests
- `cargo +stable-x86_64-pc-windows-gnu test -p gathera-common --lib -- --nocapture`
- `git diff --check`
- `cargo +stable-x86_64-pc-windows-gnu check -p gathera-contracts` currently reaches pre-existing sibling contract macro/type errors in ticket/escrow/multisig crates before completing