### PR TITLE
fix(contract): share reward precision constant

### DIFF
--- a/contract/common/src/lib.rs
+++ b/contract/common/src/lib.rs
@@ -1,7 +1,13 @@
 //! Gathera common utilities
 //! Minimal stub — full implementation pending Soroban SDK migration
 
-use soroban_sdk::{Address, Symbol, String, Env};
+use soroban_sdk::{Address, Env, String, Symbol};
+
+/// Fixed-point scaling factor used for staking reward-per-token arithmetic.
+///
+/// Reward accounting multiplies rates by this value before division so
+/// fractional rewards retain deterministic integer precision across contracts.
+pub const PRECISION: i128 = 1_000_000_000;
 
 /// Common status enumeration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/contract/contracts/src/cross_chain.rs
+++ b/contract/contracts/src/cross_chain.rs
@@ -6,8 +6,6 @@ use crate::types::{Config, DataKey, Tier, UserInfo, ChainConfig, CrossChainMessa
 #[contract]
 pub struct CrossChainStakingContract;
 
-const PRECISION: i128 = 1_000_000_000;
-
 /// Reentrancy guard key
 const REENTRANCY_GUARD: Symbol = symbol_short!("reentrant");
 

--- a/contract/contracts/src/storage.rs
+++ b/contract/contracts/src/storage.rs
@@ -1,7 +1,6 @@
-use crate::types::{Config, DataKey, Tier, UserInfo, ChainConfig, CrossChainMessage};
-
-
-use soroban_sdk::{Address, Env, Vec, Symbol, token};
+use crate::types::{ChainConfig, Config, CrossChainMessage, DataKey, Tier, UserInfo};
+use gathera_common::PRECISION;
+use soroban_sdk::{token, Address, Env, Symbol, Vec};
 
 const TTL_INSTANCE: u32 = 17280 * 30; // 30 days
 const TTL_PERSISTENT: u32 = 17280 * 90; // 90 days


### PR DESCRIPTION
Closes #513.

## Summary
- Moves the staking reward `PRECISION` scale into `gathera-common` with a doc comment.
- Imports the shared constant explicitly in `storage.rs` reward accounting.
- Removes the private cross-chain-local `PRECISION` constant so the workspace has a single reward precision source of truth.

## Validation
- `git diff --check -- contract/common/src/lib.rs contract/contracts/src/cross_chain.rs contract/contracts/src/storage.rs`
- `rustup run stable-x86_64-pc-windows-gnu rustfmt --edition 2021 --check contract/common/src/lib.rs contract/contracts/src/cross_chain.rs contract/contracts/src/storage.rs` showed only pre-existing formatting drift outside the touched import/constant lines after targeted cleanup.
- `cargo +stable-x86_64-pc-windows-gnu check -p gathera-common` passed.
- `cargo +stable-x86_64-pc-windows-gnu check -p gathera-contracts` still stops in existing sibling crates (`ticket_contract`, `escrow_contract`, `multisig_wallet_contract`) before project-level completion, but the filtered output has no `PRECISION` errors.

## Pre-submit checks
- Issue #513 was open and unassigned at refresh time.
- No open PR matched `#513`, `gathera_common::PRECISION`, `constant undefined`, or `shared precision`; the only `PRECISION` match was the separate reward-overflow PR #541.